### PR TITLE
build(flake): pin rainix at the rev CI runs, so the static gate runs locally

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,16 +442,17 @@
         "solc": "solc_2"
       },
       "locked": {
-        "lastModified": 1780287289,
-        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
+        "lastModified": 1783700120,
+        "narHash": "sha256-kLzVTH38WIKDzk3LM/COFQPIRDfAfC3+/t/X+KO89ao=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
+        "rev": "53e96a7d0a97d7c7c75c3b2412521324776fdac6",
         "type": "github"
       },
       "original": {
         "owner": "rainlanguage",
         "repo": "rainix",
+        "rev": "53e96a7d0a97d7c7c75c3b2412521324776fdac6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,19 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    rainix.url = "github:rainlanguage/rainix";
+    # Pinned to the rev the rainix reusable workflows run, not to rainix HEAD.
+    # Every job in `rainix.yaml` executes
+    # `nix develop github:rainlanguage/rainix/$RAINIX_SHA#sol-shell -c <task>`,
+    # where `RAINIX_SHA` is a single constant shared across every reusable in
+    # rainix. `devShells.default` here is that same `sol-shell`, so matching the
+    # rev is what makes a local run of a gate the same run CI does; anything
+    # else silently ships a second, differently-versioned toolchain that the
+    # merge gate does not use. An unpinned url does not avoid a pin — the lock
+    # file pins it regardless — it only makes the pinned rev arbitrary.
+    #
+    # Bump this whenever rainix moves `RAINIX_SHA`. Current value from
+    # https://github.com/rainlanguage/rainix/blob/main/.github/workflows/rainix-sol-static.yaml
+    rainix.url = "github:rainlanguage/rainix/53e96a7d0a97d7c7c75c3b2412521324776fdac6";
     rain.url = "github:rainlanguage/rain.cli";
   };
 


### PR DESCRIPTION
Closes #28.

`devShells.default` is rainix's `sol-shell`. Every CI job runs *that same shell*,
out of `github:rainlanguage/rainix/$RAINIX_SHA`. The lock pinned `f22d4dc`
(2026-06-01); `RAINIX_SHA` is `53e96a7` (2026-07-10); `rainix-sol-single-contract`
was added in between (rainix `befbdbc`). So the one-contract-per-file gate that
`README.md` and `CLAUDE.md` tell a contributor to run was simply absent from the
shell, and pushing was the only way to learn that a `.sol` file had grown a
second contract.

This pins the input at the rev CI runs.

## Why pinned, not `nix flake update`

**An unpinned url does not give you a floating rainix.** `flake.lock` pins it
either way. The only questions are *which* rev is pinned and *whether that rev
means anything*. Today it means nothing: I checked eight consumers in the org —
`raindex`, `rain.factory`, `rain.math.float`, `rain.metadata`, `rain.erc`,
`rain.flare`, `rain.extrospection`, `rain.datacontract` — and every one is locked
at exactly `f22d4dc`, the same rev this repo was on. The convention is producing
one frozen org-wide snapshot that is nobody's CI rev, refreshed by campaign. The
floating half of the convention that *does* keep working is `uses: …@main` on the
reusables, and this change does not touch it.

**`nix flake update` would put the shell 45 commits *ahead* of the gate.** That
is worse than being behind, because a local pass stops being evidence about CI at
all — the task binaries it runs are ones CI never runs. Between `53e96a7` and
`main`, rainix's sol task set and `rainix-static` move by ~1400 lines. Being
behind produces a missing command, which is loud. Being ahead produces a command
that exists, runs, and answers a different question — which is silent, and is the
failure mode #28 describes, inverted and harder to diagnose.

**`RAINIX_SHA` is already single-sourced.** rainix `a867dd8` ("single-source
RAINIX_SHA across reusable workflows") made one constant govern every reusable.
It is the repo's answer to "which rainix gates this?". Matching it means this
repo has one rainix, not two independently-versioned ones.

**The cost is bounded and rare.** A manual bump when `RAINIX_SHA` moves — twice
ever, 2026-06-28 and 2026-07-10. Unlike silent lock drift, the obligation is
written next to the SHA in `flake.nix`, along with the URL to read the current
value from.

## Blast radius: task definitions only

rainix's own `flake.lock` is byte-identical at `f22d4dc`, `53e96a7` and `main`.
Confirmed empirically — the shell's store paths are unchanged from the ones #28
recorded before this change:

```
forge                      /nix/store/zb1ia37q…-foundry-0.0.0/bin/forge
slither                    /nix/store/c8gqgnqz…-python3.13-slither-analyzer-0.11.5/bin/slither
reuse                      /nix/store/7vlrdv22…-python3.13-reuse-6.2.0/bin/reuse
solc                       /nix/store/9cfhmw2m…-python3.13-solc-select-1.2.0/bin/solc
rainix-sol-single-contract /nix/store/dxkcwl7f…-rainix-sol-single-contract/bin/…   ← was MISSING
```

`slither` and `forge fmt` output cannot move as a result. The `flake.lock` diff
is 4 lines; no transitive input changed.

## The third option, and why it is not in this PR

The pin fixes *this* repo but leaves the general defect: a consumer's lock rev
and `RAINIX_SHA` are two copies of one invariant, and nothing checks them against
each other. The self-correcting version is a check that fails when they diverge,
naming the rev to bump to.

That check is identical in every consumer repo, which makes it shared CI, which
by convention lives in rainix's reusables rather than being hand-rolled here.
Building it in `rain.deploy` would put org-wide CI in a consumer and leave the
next repo to copy it. It should be a rainix issue; I have not filed one, since
that is a different repo from the one this issue is in — happy to.

Not touched: the unused `rain` input, which is #29.

## Verification

In `nix develop` on this branch:

| gate | result |
| --- | --- |
| `rainix-sol-single-contract` | exit 0 — **the gate #28 is about; it could not run at all before** |
| `slither .` | exit 0 — 44 contracts, 100 detectors, 0 results |
| `forge fmt --check` | exit 0 |
| `reuse lint` | exit 0 |
| `forge test --no-match-contract Chain` | 93 passed, 26 failed |

All 26 failures are environmental: there is no `.env`, and every one of them is
`vm.createSelectFork: environment variable ARBITRUM_RPC_URL / BASE_RPC_URL not
found`, all in `test/src/lib/LibRainDeploy.t.sol`. `origin/main` gives the same
93/26 split in the same shell, so this change moves nothing — as it cannot, the
`forge` binary being the identical store path either side.

pre-commit (`deadnix`, `nil`, `nixfmt`, `statix`) passes on the edited
`flake.nix`.

## QA

- **Discriminating tests:** the issue's own reproduce command,
  `nix develop -c bash -c 'command -v rainix-sol-single-contract || echo MISSING'`.
  Fails on base — run in a worktree at `origin/main` (`8d1e5fd`) it prints
  `MISSING`; on this branch it resolves to
  `/nix/store/dxkcwl7f…-rainix-sol-single-contract/bin/rainix-sol-single-contract`.
  The gate itself then runs: `rainix-sol-single-contract` exits 0 here and cannot
  be invoked at all on base.
- **Mutations applied:** the pinned rev is the only semantic value in the diff.
  (1) `flake.nix` rev → `f22d4dc…` — this is exactly the base state, and the
  check reports `MISSING`; killed by the discriminating test above. (2) rev →
  rainix `main` (`8af258f`) — the presence check would stay green, which is why
  presence alone is *not* the oracle for this PR's actual claim; the rev-equality
  check below is what kills that mutant.
- **Oracle:** rainix's own
  `.github/workflows/rainix-sol-static.yaml` at `main`, read from the rainix
  repo — `RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6`. Independent of
  everything in this repo. `flake.nix` and the *root* `rainix_2` node of
  `flake.lock` (not the `rainix` node, which is rain.cli's two-year-old one —
  the trap #28 documents) both read `53e96a7…` in `locked` and `original`;
  `origin/main`'s `rainix_2` reads `f22d4dc…`. Toolchain non-movement has its own
  oracle: nix store paths compared against the ones #28 recorded pre-change.
- **Category check:** #28 asks for two things — (a) the dev shell must provide
  `rainix-sol-single-contract` so the documented static gate runs locally, and
  (b) an explicit maintainer decision between floating and pinning, with reasons.
  Both covered: (a) verified by the discriminating test, (b) argued above, with
  the third (drift-check) option named and routed to rainix rather than silently
  dropped. No mutation testing of Solidity applies — the diff contains no
  Solidity and no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Rainix integration to a specific revision for more consistent and reproducible builds.
  * Added documentation clarifying synchronization with the CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->