### PR TITLE
build(flake): drop the `rain` input nothing reads, and the stale rainix it pulled

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,93 +39,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_7": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
         "lastModified": 1731533236,
         "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
@@ -139,7 +52,7 @@
         "type": "github"
       }
     },
-    "flake-utils_8": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -154,9 +67,9 @@
         "type": "github"
       }
     },
-    "flake-utils_9": {
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -174,28 +87,8 @@
     },
     "foundry": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1714727549,
-        "narHash": "sha256-CWXRTxxcgMfQubJugpeg3yVWIfm70MYTtgaKWKgD60U=",
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "rev": "47cf189ec395eda4b3e0623179d1075c8027ca97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "shazow",
-        "ref": "monthly",
-        "repo": "foundry.nix",
-        "type": "github"
-      }
-    },
-    "foundry_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1778486972,
@@ -215,7 +108,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1778507602,
@@ -269,67 +162,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714764285,
-        "narHash": "sha256-oeevp27kMeDjKdxaTyXyS14TLjJrpJhXp7UVEUdYqYs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d121ce778b2609ae9e749a711295ffca013a82c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1708564076,
-        "narHash": "sha256-KKkqoxlgx9n3nwST7O2kM8tliDOijiSSNaWuSkiozdQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1666753130,
-        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
         "lastModified": 1770073757,
         "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
@@ -344,7 +176,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1778656924,
         "narHash": "sha256-lKVrom9wOmpC3i7m+uBoGaBdW0PfH3QbLRG1XmuC6YA=",
@@ -359,7 +191,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -375,7 +207,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1777641297,
         "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
@@ -391,55 +223,14 @@
         "type": "github"
       }
     },
-    "rain": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "rainix": "rainix"
-      },
-      "locked": {
-        "lastModified": 1714768001,
-        "narHash": "sha256-Vv5FZx6AFaHsJWQl5bsuhLbY8NWGeD0JHbAdceVZMqo=",
-        "owner": "rainlanguage",
-        "repo": "rain.cli",
-        "rev": "dc7ffe3b905ca57e92be6f294426f32fcf8005eb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rainlanguage",
-        "repo": "rain.cli",
-        "type": "github"
-      }
-    },
     "rainix": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_3",
         "rust-overlay": "rust-overlay",
         "solc": "solc"
-      },
-      "locked": {
-        "lastModified": 1714764843,
-        "narHash": "sha256-7ae0pHvjlInc1V3QxjW5iNhXAYerO1/fhLgzQnPNPjE=",
-        "owner": "rainlanguage",
-        "repo": "rainix",
-        "rev": "f3bdb28f353f8cba28b2bba86f79c362dd65ee53",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rainlanguage",
-        "repo": "rainix",
-        "type": "github"
-      }
-    },
-    "rainix_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_7",
-        "foundry": "foundry_2",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs_7",
-        "rust-overlay": "rust-overlay_2",
-        "solc": "solc_2"
       },
       "locked": {
         "lastModified": 1780287289,
@@ -458,32 +249,12 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "rain": "rain",
-        "rainix": "rainix_2"
+        "rainix": "rainix"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1714702555,
-        "narHash": "sha256-/NoUbE5S5xpK1FU3nlHhQ/tL126+JcisXdzy3Ng4pDU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "7f0e3ef7b7fbed78e12e5100851175d28af4b7c6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1778642276,
@@ -501,15 +272,16 @@
     },
     "solc": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_5",
+        "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1711538161,
-        "narHash": "sha256-rETVdEIQ2PyEcNgzXXFSiYAYl0koCeGDIWp9XYBTxoQ=",
+        "lastModified": 1777817996,
+        "narHash": "sha256-iI71iUhD7THLibl3w1JcQEhHmTwZMxChi70RTe33BAo=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "a995838545a7383a0b37776e969743b1346d5479",
+        "rev": "e3cf898cb804d5c0e5474b378a300fe8942e67d6",
         "type": "github"
       },
       "original": {
@@ -528,26 +300,6 @@
       "original": {
         "type": "file",
         "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
-      }
-    },
-    "solc_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_9",
-        "nixpkgs": "nixpkgs_9",
-        "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
-      },
-      "locked": {
-        "lastModified": 1777817996,
-        "narHash": "sha256-iI71iUhD7THLibl3w1JcQEhHmTwZMxChi70RTe33BAo=",
-        "owner": "hellwolf",
-        "repo": "solc.nix",
-        "rev": "e3cf898cb804d5c0e5474b378a300fe8942e67d6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hellwolf",
-        "repo": "solc.nix",
-        "type": "github"
       }
     },
     "systems": {
@@ -581,66 +333,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_7": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     rainix.url = "github:rainlanguage/rainix";
-    rain.url = "github:rainlanguage/rain.cli";
   };
 
   outputs =


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/29

`rain.url = "github:rainlanguage/rain.cli"` was declared and never referenced —
`outputs` destructures `flake-utils` and `rainix`, and `...` swallowed the rest.

It was not inert. rain.cli carries its own rainix, so the lock held two rainix
nodes and a bare grep for `"rainix": {` hit the 2024 one (`f3bdb28`,
lastModified 1714764843) rather than the one root actually resolves (`f22d4dc`,
lastModified 1780287289). That is an answer two years wrong, and two readers
have already given it.

## The diff

`flake.nix`: one line deleted. `outputs` is untouched.

`flake.lock`: `nix flake lock` — not `nix flake update`, so nothing that
survives is re-resolved. 19 insertions, 327 deletions; the insertions are
renumbering (`rainix_2` becomes `rainix` once the name collision is gone), not
new content.

Nix names the 18 nodes it drops, and they are exactly the `rain` subtree:

```
Removed input 'rain'                                  rainlanguage/rain.cli @ dc7ffe3
Removed input 'rain/rainix'                           rainlanguage/rainix   @ f3bdb28  <- the trap
Removed input 'rain/rainix/foundry'                   shazow/foundry.nix    @ 47cf189
Removed input 'rain/rainix/solc'                      hellwolf/solc.nix     @ a995838
Removed input 'rain/rainix/rust-overlay'              oxalica/rust-overlay  @ 7f0e3ef
Removed input 'rain/rainix/nixpkgs'                   nixos/nixpkgs         @ d121ce7
Removed input 'rain/rainix/foundry/nixpkgs'           NixOS/nixpkgs         @ f540aed
Removed input 'rain/rainix/rust-overlay/nixpkgs'      NixOS/nixpkgs         @ 90f4560
Removed input 'rain/rainix/solc/nixpkgs'              NixOS/nixpkgs         @ 98b00b6
+ 9 transitive flake-utils / systems nodes
```

Node count 39 -> 21. Comparing the two locks by locked `owner/repo@rev` rather
than by node name — because the names renumber — the set present in `main` but
not here is exactly those 18, and **the set present here but not in `main` is
empty**. Nothing was added and no surviving pin moved.

Root inputs after: `{"flake-utils":"flake-utils","rainix":"rainix"}`, and
`.nodes.rainix.locked.rev` is `f22d4dcaca61717e33eac65e7b09b9a82f604c1f` — the
same rev `main` resolves today. There is now exactly one node whose name starts
with `rainix`, so the grep that misled two readers can no longer land on the
wrong one.

Out of scope by design: this does **not** bump the rainix pin.
https://github.com/rainlanguage/rain.deploy/issues/28 covers the drift between
`f22d4dc` and CI's `RAINIX_SHA`, and a separate PR is moving it.

## The shell is unchanged

The strongest available evidence, not a description of one — the devShell
derivation is byte-identical either side:

```
main       nix eval .#devShells.x86_64-linux.default.drvPath
           /nix/store/pjvqlx8szgs29midvh0fr1r2isw5ikkc-nix-shell.drv
this PR    /nix/store/pjvqlx8szgs29midvh0fr1r2isw5ikkc-nix-shell.drv
```

Same for every attr of `packages.x86_64-linux` (`prettier-bundle`,
`rainix-rs-static`, `rainix-sol-artifacts`, `rust-shell-test`,
`sol-shell-test`) — all five `drvPath`s compare equal.

## Gates, against a bare `origin/main` baseline

Both columns are the same machine, the same `nix develop -c`, no `.env` — this
repo does not ship one. `main` moved to `d08203e` (#20) while this was open, so
it is merged in here — merged, not rebased — and the numbers below are the merge
commit against `origin/main` at `d08203e` in its own worktree. After that merge
the only files this branch differs from `main` by are still `flake.nix` and
`flake.lock`, and the devShell derivation is still
`/nix/store/pjvqlx8szgs29midvh0fr1r2isw5ikkc-nix-shell.drv` on both sides.

| gate (what rainix CI actually runs) | `origin/main` `d08203e` | this PR |
| --- | --- | --- |
| `forge soldeer install` | 0 | 0 |
| `reuse lint` (legal) | 0 | 0 |
| `slither .` (static) | 0 | 0 |
| `forge fmt --check` (static) | 0 | 0 |
| `rainix-sol-single-contract` (static) | 127 | 127 |
| `forge test -vvv` | 1 | 1 |

`forge test`: **142 tests, 95 passed, 47 failed on both**, and the set of
failing test names is byte-identical between the two — `diff` of the sorted name
lists is empty. Before merging `main` in, the same comparison at `fc4fdc9` gave
141 / 95 / 46, likewise identical either side; #20 added the extra fork test.

All 47 failures are environmental: every one is
``vm.createSelectFork: environment variable `<NETWORK>_RPC_URL` not found``
(`ARBITRUM_RPC_URL`, `BASE_RPC_URL`). Filtering the `[FAIL` lines for anything
that is *not* that message returns 0 on both sides. They are `LibRainDeployTest`
(38), `RainDeployVerifyChainTest` (7) and `RainDeployVerifyChainCandidateTest`
(2) — the fork suites. `forge test --no-match-contract Chain` is the snapshot
gate and it is green; CI supplies the endpoints through its rpc-preflight step.

`rainix-sol-single-contract` exits 127 (command not found) on **both** sides:
the flake-pinned rainix `f22d4dc` predates that script, while CI runs
`RAINIX_SHA` `53e96a7`, which has it. Unmoved by this PR, and it is a symptom of
exactly the drift #28 is about.

Also of note: pre-commit's nix hooks (`deadnix`, `nixfmt`, `statix`, `nil`) all
pass on the edited `flake.nix`.

## QA
- Discriminating tests: n/a as new Solidity tests — the diff is `flake.nix` +
  `flake.lock` and compiles no code. The discriminating check is differential
  against `origin/main` `d08203e` in a second worktree, and it does fail on
  base: `jq -r '[.nodes|keys[]|select(startswith("rainix"))]|join(",")'` returns
  `rainix,rainix_2` on base and `rainix` here, and the by-`owner/repo@rev`
  set-difference is 18 nodes dropped / 0 added on base-vs-head where base-vs-base
  is empty. The non-regression check is the other direction and is inert on base
  by construction: `devShells.x86_64-linux.default.drvPath` is
  `/nix/store/pjvqlx8szgs29midvh0fr1r2isw5ikkc-nix-shell.drv` on both, all five
  `packages.x86_64-linux` `drvPath`s compare equal, and `forge test` gives the
  same 95 passed / 47 failed with a byte-identical failing-name set.
- Mutations applied: n/a — there is no line of executable code in this diff to
  mutate; the only change is the deletion of an unused flake input and the
  regenerated lock. The equivalent adversarial probe was run instead: `nix flake
  lock` (never `update`), then the two locks compared by locked
  `owner/repo@rev` rather than by node name, because nix renumbers `rainix_2` to
  `rainix` and a name-keyed diff would have reported 18 "removals" that are
  really renames and hidden a genuine pin move inside them. That probe would
  catch a silent re-resolution; it reports zero added and zero moved.
- Oracle: nix itself, not this change's own output. The dropped set is what `nix
  flake lock` printed as `Removed input 'rain/...'` (18 lines), cross-checked
  independently against the locked revs in `main`'s `flake.lock` reachable only
  from `root.inputs.rain`. The unchanged-shell claim is the store path nix
  derives, which is a hash of the shell's full closure and is not something this
  PR can assert about itself. The 47 environmental failures are read from
  forge's own `[FAIL: ...]` reason strings, not inferred from the count.
- Category check: the issue asks for exactly two things — remove `rain` from
  `inputs`, and regenerate `flake.lock` so the orphaned nodes drop out. Both
  done, and its stated non-goal is honoured: the rainix pin is NOT bumped, it is
  `f22d4dc` before and after, leaving #28 the whole of that question. The issue
  also states "nothing in `outputs` changes" — `outputs` is untouched, which the
  identical devShell derivation confirms rather than merely asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

