### PR TITLE
docs: say what findDeployBlock, isStartBlock and the deploy actually do

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,13 @@ These are referenced in `foundry.toml` under `[rpc_endpoints]`.
   returns the deployed address
 - `supportedNetworks()` — returns the list of Rain-supported network names (used
   as foundry RPC config aliases)
-- `isStartBlock(...)` / `findDeployBlock(...)` — binary search a fork's history
-  for the block a contract first appears at
+- `isStartBlock(...)` — reads two adjacent blocks: true when the target has the
+  expected code hash at a block and does not have it at the block before
+- `findDeployBlock(...)` — binary searches a fork's history for a block where
+  the target has the expected code hash and did not have it at the block before.
+  Either one is "the block a contract first appears at" only where that code
+  hash is monotone; against a target that held the hash, lost it and holds it
+  again both answer about an appearance neither can identify
 - `checkResolvedAddresses(...)` — asserts an already-deployed contract holds the
   addresses the deployment expected, on the currently selected fork, via
   consumer-supplied static reads

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,10 @@ These are referenced in `foundry.toml` under `[rpc_endpoints]`.
   is the only point at which such a check means anything: registry bindings are
   mutable, so a pre-deploy check would read a source that can change before the
   constructor that consumes it
-- `deployToNetworks(...)` — forks each network, verifies the factory and
-  dependencies, deploys via Zoltu, verifies address and code hash
+- `deployToNetworks(...)` — forks each network; where the expected address is
+  still empty it verifies the factory and dependencies on that fork, deploys via
+  Zoltu and checks the address; the code hash is checked on every network,
+  deployed here or already there
 - `deployAndBroadcast(...)` — the main entry point: derives the deployer from a
   private key, then `deployToNetworks`
 
@@ -292,8 +294,13 @@ expected addresses, expected code hashes, and dependency lists.
 - **Code hash verification**: Post-deploy bytecode integrity is verified against
   `expectedCodeHash`. The address registry is verified the same way before it is
   read.
-- **Dependency checking**: Before deploying to any network, all dependencies
-  (contract addresses) are verified to have code on-chain.
+- **Dependency checking**: per network, and only where the deploy actually runs.
+  On a network with no code at `expectedAddress`, the Zoltu factory must have
+  code and match `ZOLTU_FACTORY_CODEHASH` and every dependency must have code,
+  all read on that network's own fork immediately before broadcasting. A network
+  that already has the code skips the deploy and the dependency check with it: a
+  contract that is already deployed does not need its dependencies present to
+  stay deployed. There is no all-network pre-flight.
 - **Idempotent deploys**: If code already exists at the expected address,
   deployment is skipped for that network.
 - **Resolve once, verify after**: registry bindings are mutable, so the

--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -81,6 +81,15 @@ library LibRainDeploy {
     /// hash at `blockNumber` and does NOT have it at `blockNumber - 1`. At
     /// block 0, only the first condition is checked. The fork is restored to
     /// its original block number after checking.
+    ///
+    /// "First" is only true of a target whose code hash is MONOTONE: once it
+    /// equals `expectedCodeHash` at some block it equals it at every later
+    /// block. This reads two adjacent blocks and nothing else, so on a target
+    /// that held `expectedCodeHash`, lost it and holds it again — a pre-Cancun
+    /// `SELFDESTRUCT` followed by a `CREATE2` redeploy of the same code at the
+    /// same address, say — it answers true at EVERY block where the hash
+    /// reappears, not only the earliest. Monotonicity is the caller's to know:
+    /// two blocks cannot show it.
     /// @param vm The Vm instance for fork manipulation.
     /// @param target The contract address to check.
     /// @param expectedCodeHash The code hash to look for.
@@ -104,8 +113,20 @@ library LibRainDeploy {
     /// searching the fork history. Requires an active fork with archive access
     /// back to `startBlock`. The fork is restored to its original block
     /// number before returning. The target's code hash is verified against the
-    /// expected value before searching. The result is validated via
-    /// `isStartBlock`.
+    /// expected value before searching.
+    ///
+    /// The search REQUIRES the target's code hash to be monotone over
+    /// `[startBlock, block.number]`, in the sense `isStartBlock` describes.
+    /// Against a target that held `expectedCodeHash`, lost it and holds it
+    /// again, the search converges on one of those appearances with no way to
+    /// say which, and the result is meaningless as the subgraph start block it
+    /// is typically used as.
+    ///
+    /// That is the caller's precondition because nothing here can check it, and
+    /// `isStartBlock` least of all: the loop exits with the code hash matching
+    /// at the result and not matching at the block before it whatever the
+    /// history, so `isStartBlock` holds of the result by construction and
+    /// running it here could only ever agree.
     /// @param vm The Vm instance for fork manipulation.
     /// @param target The contract address to search for.
     /// @param expectedCodeHash The expected code hash of the target contract.

--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -126,11 +126,16 @@ library LibRainDeploy {
     ///
     /// That is the caller's precondition because nothing here can check it, and
     /// `isStartBlock` least of all. `high` is only ever a block where the code
-    /// hash matches and `low` is only ever one past a block where it does not,
-    /// so where they meet the hash matches and did not match at the block
-    /// before — `isStartBlock`'s exact condition, satisfied by construction and
-    /// satisfied on a non-monotone history just the same. Running it on the
-    /// result would read two more archive blocks to agree with itself.
+    /// hash matches: it starts at the current block, checked above, and
+    /// otherwise takes a `mid` the loop has just read as matching. `low` is
+    /// either `startBlock`, checked above as NOT matching, or one past a `mid`
+    /// the loop has just read as not matching. It cannot still be `startBlock`
+    /// when the loop ends, because that needs `high` down at `startBlock` and
+    /// `high` is only ever a matching block, so where they meet the hash
+    /// matches and did not match at the block before — `isStartBlock`'s exact
+    /// condition, satisfied by construction and satisfied on a non-monotone
+    /// history just the same. Running it on the result would read two more
+    /// archive blocks to agree with itself.
     /// @param vm The Vm instance for fork manipulation.
     /// @param target The contract address to search for.
     /// @param expectedCodeHash The expected code hash of the target contract.

--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -125,10 +125,12 @@ library LibRainDeploy {
     /// is typically used as.
     ///
     /// That is the caller's precondition because nothing here can check it, and
-    /// `isStartBlock` least of all: the loop exits with the code hash matching
-    /// at the result and not matching at the block before it whatever the
-    /// history, so `isStartBlock` holds of the result by construction and
-    /// running it here could only ever agree.
+    /// `isStartBlock` least of all. `high` is only ever a block where the code
+    /// hash matches and `low` is only ever one past a block where it does not,
+    /// so where they meet the hash matches and did not match at the block
+    /// before — `isStartBlock`'s exact condition, satisfied by construction and
+    /// satisfied on a non-monotone history just the same. Running it on the
+    /// result would read two more archive blocks to agree with itself.
     /// @param vm The Vm instance for fork manipulation.
     /// @param target The contract address to search for.
     /// @param expectedCodeHash The expected code hash of the target contract.

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -358,7 +358,8 @@ contract LibRainDeployTest is Test {
     }
 
     /// `deployZoltu` MUST deploy a contract via the Zoltu factory and return
-    /// the deterministic address predicted by the factory's nonce.
+    /// the deterministic address the factory derives with `CREATE2` over the
+    /// creation code under a zero salt.
     function testDeployZoltu() external {
         vm.createSelectFork(LibRainDeploy.ARBITRUM_ONE);
         address deployed = this.externalDeployZoltu(type(MockDeployable).creationCode);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/18

Every one of the five was re-established against `main` at `d08203e` before
anything was changed. Two are already fixed and are untouched here.

## Already fixed on `main` — no change

**5, and the `CLAUDE.md` half of 2.** `bf5ac30` replaced "uses CREATE with a
predictable nonce" with `CREATE2` over the factory's calldata under a zero salt,
and added Base Sepolia to the network list in the same edit; `10b14d5` added
`BASE_SEPOLIA_RPC_URL` to the sample `.env`. Every site the issue names for
those two is correct on `main`.

**The `checkDependencies` half of 1.** #26 rewrote the architecture section:
neither `checkDependencies` nor "**re**-verifies dependencies" survives it.

## 1 — dependency checking is per network, and only where the deploy runs

The Key Design Patterns bullet the issue also quotes is untouched since the file
was created:

> **Dependency checking**: Before deploying to any network, all dependencies
> (contract addresses) are verified to have code on-chain.

It reads as an all-network pre-flight, which is the one thing the
`deployToNetworks` NatSpec itself says does not exist — "which is why no separate all-network
pre-flight is needed". Replaced with what the code does: per network, on that
network's own fork, immediately before broadcasting, and only on the branch that
broadcasts — factory code and `ZOLTU_FACTORY_CODEHASH`, then code at every
dependency. The architecture bullet for `deployToNetworks` carried the same
overstatement one line long and is fixed with it; the code hash check is the only
part of it that runs on both branches.

## 2 — the second site: a test comment

`testDeployZoltu`'s doc comment still said the returned address is "the
deterministic address predicted by the factory's nonce". Under that model the
address depends on per-chain deploy order; under the actual CREATE2-salt-0 model
it is a pure function of the creation code, which is the property this whole
library rests on. Now says what the factory does.

## 3 — the sentence is dropped rather than implemented

`findDeployBlock`'s NatSpec claimed "The result is validated via `isStartBlock`".
It is not, and implementing it would be worse than the false claim.

**The check cannot fail.** `high` starts at a block where the code hash matches
(checked on entry) and is only ever assigned a `mid` where it matches. `low`
starts at `startBlock`, where the hash does not match (checked before the loop),
and thereafter is only ever `mid + 1` for a `mid` where it did not match. `low`
cannot exit still equal to `startBlock`, because that needs `high` to descend to
`startBlock` and `high` only ever takes blocks where the hash matches. So at exit
`low == high` is a block where the hash matches whose predecessor is a block
where it does not — `isStartBlock`'s exact condition. Calling `isStartBlock` on
the result is a tautology.

**It would be a tautology dressed as a guard.** What actually makes a result
meaningless is a non-monotone history (item 4), and `isStartBlock` reads two
adjacent blocks, so it is blind to precisely that. A check that can only ever
agree, sitting where a reader expects the guard against the real hazard, is worse
than no check: it enshrines the assurance it does not provide.

**And it is the redundant re-read this library already argues against by name.**
`deployToNetworks` explains it reads each dependency exactly once so "a transient
RPC inconsistency on a redundant second read cannot report an already-deployed
dependency as missing and abort an otherwise-valid deploy". Three more archive
round trips that can only agree carry that same failure mode and none of the
upside.

`testFindDeployBlockZoltuFactory` already asserts `isStartBlock` of the result on
a Base fork. That is where the sentence came from, and where the round trip
belongs.

## 4 — the monotonicity requirement holds, and is now stated

Checked before writing it down. The search needs the predicate
`codehash == expectedCodeHash` to be monotone over `[startBlock, block.number]`:
once true, true at every later block. Worked through on the non-monotone history
`F F T T F F F T T T T` over blocks 0..10, the search returns 7 — a block that
satisfies `isStartBlock` and is not the first appearance, which is 2.

`isStartBlock` needs it too, in its own form. It answers on two adjacent blocks,
so against a target that held the hash, lost it and holds it again it answers
true at every reappearance rather than only the earliest, while its NatSpec calls
what it identifies "the first". Both now say so, with a pre-Cancun
`SELFDESTRUCT` and `CREATE2` redeploy of the same code at the same address as the
concrete instance.

## Verification

Via `nix develop -c`, on the merge of `main`:

- `forge fmt --check` — clean
- `reuse lint` — compliant, 55/55 files
- `slither .` — 44 contracts, 100 detectors, 0 results
- `forge test` — 95 passed, 47 failed, 142 total

Bare `origin/main` at `d08203e`, same checkout, same shell: 95 passed, 47 failed,
142 total. Identical. Every one of the 47 is
`vm.createSelectFork: environment variable *_RPC_URL not found` — there is no
`.env` in this environment, so every fork test fails before it runs. Filtering
the failure list for anything that is not an RPC-env error returns nothing, on
both sides.

## QA
- Discriminating tests: n/a — the diff is comments and Markdown only, so no
  compiled statement changes and no test can distinguish it from base. The
  property the rewritten `findDeployBlock` NatSpec asserts is already covered:
  `testFindDeployBlockZoltuFactory` asserts `isStartBlock` of the search result
  on a Base fork.
- Mutations applied: n/a — a docs-only diff has no line whose mutation changes
  behaviour. Verified as such rather than assumed: `forge test` is 95 passed / 47
  failed / 142 total on this branch and 95 / 47 / 142 on bare `origin/main` at
  `d08203e`, run in the same checkout and the same `nix develop` shell, which is
  what a comment-only diff must produce.
- Oracle: the code, not the issue's report of the code. Each of the five claims
  was re-derived against `main` at `d08203e` before anything was edited — the
  address derivation from `zoltuAddress` and `ZOLTU_FACTORY_BYTECODE`, the
  dependency-check branch structure from `deployToNetworks` itself, and the
  `isStartBlock`-is-a-tautology result from the binary search's own loop
  invariants, worked through on an explicit non-monotone history
  (`F F T T F F F T T T T` over blocks 0..10 returns 7, not 2).
- Category check: the issue asks for 1, 2, 3, 4, 5; covered 1, 2, 3, 4 here. 5,
  and the `CLAUDE.md` sites of 1 and 2, were already fixed on `main` by
  `bf5ac30`, `10b14d5` and #26 — reported above rather than silently dropped, and
  deliberately not "re-fixed". The second site of 2 that the issue mentions in
  passing, the `testDeployZoltu` comment, is included because #26 did not reach
  `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
