### PR TITLE
build(flake): update the rainix lock pin so the static gate runs locally

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
         "solc": "solc_2"
       },
       "locked": {
-        "lastModified": 1780287289,
-        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
+        "lastModified": 1786434462,
+        "narHash": "sha256-/AnWHKrMmioSWhmPF2ktGVw9/MJVzm3vA8SCuiVcuO0=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
+        "rev": "8af258f90b43d38391431d60f2156e7f534cbd9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/28.

`devShells.default` is rainix's `sol-shell`. The lock pinned it at `f22d4dc`
(2026-06-01), which predates `rainix-sol-single-contract`. `README.md` and
`CLAUDE.md` both tell a contributor to run that gate locally, and
`rainix-sol-static.yaml` runs it in CI, but it was not in the shell — so the
only way to learn that a `.sol` file had grown a second contract was to push.

## The diff

`flake.lock` only, 3 lines, on the root's `rainix` node:

```diff
-        "lastModified": 1780287289,
-        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
+        "lastModified": 1786434462,
+        "narHash": "sha256-/AnWHKrMmioSWhmPF2ktGVw9/MJVzm3vA8SCuiVcuO0=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
+        "rev": "8af258f90b43d38391431d60f2156e7f534cbd9d",
```

`git diff origin/main --stat` is `flake.lock | 6 +++---`. **`flake.nix` is not
touched** — no rev in the url, so this stays byte-identical to the other eight
consumers and there is no hand-bumped constant to keep in sync. That is the
point https://github.com/rainlanguage/rain.deploy/pull/30 got wrong and was
closed for.

Produced by `nix flake lock --update-input rainix` — the lock-only,
single-input update. (This is `nix flake update rainix` on nix >= 2.19; on the
nix 2.18 here, `nix flake update` takes a flake-url and re-resolves *every*
input, which is not what is wanted.) Nix's own report:

```
• Updated input 'rainix':
    'github:rainlanguage/rainix/f22d4dcaca61717e33eac65e7b09b9a82f604c1f' (2026-06-01)
  → 'github:rainlanguage/rainix/8af258f90b43d38391431d60f2156e7f534cbd9d' (2026-08-11)
```

No transitive input moved: rainix's own `flake.lock` is byte-identical at
`f22d4dc` and at `8af258f`, so nixpkgs, foundry.nix, solc.nix and rust-overlay
are the same revs before and after. That is why the diff is 3 lines and not a
lock rewrite.

`main` at `ed75b87` is merged in (merged, never rebased), which landed
https://github.com/rainlanguage/rain.deploy/pull/31 (the dead `rain` input,
issue #29). The `flake.lock` conflict was resolved by taking `main`'s lock
whole and re-running the update command on top of it, not by hand-merging,
so nothing from the deleted `rain` subtree can come back. After the merge:

- root inputs are exactly `{"flake-utils": "flake-utils", "rainix": "rainix"}`
- exactly **one** node whose name starts with `rainix` (the `rainix_2` /
  `rainix` ambiguity #28 warns about is gone with #31, and this PR does not
  reintroduce it)
- node count 21, unchanged from `main`
- that one node's rev is `8af258f`

## What this does and does not buy

`8af258f` is rainix `main`. CI's `RAINIX_SHA` is `53e96a7`, 45 commits behind
it. So local is now *ahead* of CI rather than 138 commits behind, and the two
pins remain independently versioned. That is deliberate: pinning `flake.nix` at
`RAINIX_SHA` buys nothing enforceable — it goes stale the moment rainix moves
`RAINIX_SHA`, undetected, and costs a hand-bumped constant in ~40 consumer
repos. The structural fix is to drop `RAINIX_SHA` from the sol path so the
reusables run `nix develop -c` against the consumer's own checkout, leaving one
pin, in `flake.lock`. That belongs in rainix, not here.

What this PR buys is exactly what #28 reports: the documented static gate runs.

## Before / after — the payoff

Same machine, same command, no `.env`.

| | `origin/main` @ `ed75b87` | this branch @ `797a092` |
| --- | --- | --- |
| `command -v rainix-sol-single-contract` | **MISSING** | `/nix/store/dxkcwl7f…-rainix-sol-single-contract/bin/rainix-sol-single-contract` |
| `nix develop -c rainix-sol-single-contract` | **exit 127** (command not found) | **exit 0** |

The issue's own reproduce command,
`nix develop -c bash -c 'command -v rainix-sol-single-contract || echo MISSING'`,
prints `MISSING` on base and a store path here. It fails on base by
construction, which is what makes it discriminating.

## Blast radius: task scripts only, no toolchain movement

`devShells.x86_64-linux.default.drvPath` moves, as it must — the shell gains a
command:

```
origin/main  /nix/store/pjvqlx8szgs29midvh0fr1r2isw5ikkc-nix-shell.drv
this branch  /nix/store/s5zmpsky4z4mml493pdwcb49syc4x9zb-nix-shell.drv
```

Diffing what is actually *on* `PATH` in each shell shows the move is task
scripts and their runtime deps, and nothing else. **Versions and store paths of
every analysis tool are identical**:

```
forge    1.7.2-nightly            /nix/store/zb1ia37q…-foundry-0.0.0/bin/forge
solc     0.8.36+commit.8a079791   /nix/store/9cfhmw2m…-solc-select-1.2.0/bin/solc
slither  0.11.5                   /nix/store/c8gqgnqz…-slither-analyzer-0.11.5/bin/slither
reuse    6.2.0                    /nix/store/7vlrdv22…-reuse-6.2.0/bin/reuse
```

— byte-for-byte the same lines on both sides. `rustc`/`cargo` are absent from
`sol-shell` on both sides. So `forge fmt`, `slither` and compiled bytecode
cannot move as a result of this change, and the snapshot pins are untouched.

Commands **added** to the shell: `rainix-sol-single-contract`, `rainix-static`,
and the transitive CLI bins those pull in (`curl`, `openssl`, `zstd`, `brotli`,
`nghttp2`, krb5's `k*`, `idn2`, `psl`). `rainix-sol-artifacts` is rebuilt at a
new store path — it is a rainix task script and its script changed. Commands
**removed**: none.

## Gates, against a bare `origin/main` baseline

Both columns are `nix develop -c` on the same machine, `origin/main` @
`ed75b87` in its own worktree vs this branch's merge commit `797a092`. There is
no `.env` in this repo.

| gate (what rainix CI runs) | `origin/main` | this PR |
| --- | --- | --- |
| `forge soldeer install` | 0 | 0 |
| `reuse lint` (legal) | 0 | 0 |
| `slither .` (static) | 0 | 0 |
| `forge fmt --check` (static) | 0 | 0 |
| **`rainix-sol-single-contract`** (static) | **127** | **0** |
| `forge test --no-match-contract Chain` | 93 passed / 38 failed | 93 passed / 38 failed |

`slither .` reports `44 contracts with 100 detectors, 0 result(s) found` on both.

**All 38 `forge test` failures are environmental, on both sides.** Every `[FAIL`
reason is ``vm.createSelectFork: environment variable `<NETWORK>_RPC_URL` not
found`` — 23 `ARBITRUM_RPC_URL`, 15 `BASE_RPC_URL`; filtering the failure lines
for anything that is *not* that message returns 0 on both sides. All 38 are in
`test/src/lib/LibRainDeploy.t.sol:LibRainDeployTest` (54 tests, 16 pass). The
sorted set of failing test names is identical between base and this branch —
`diff` is empty. CI supplies those endpoints; a local checkout does not have
them.

pre-commit ran on both commits (`deadnix`, `nil`, `nixfmt`, `statix`,
`shellcheck`, `taplo`, `yamlfmt`, …) and passed.

## QA

- **Discriminating test:** the issue's own reproduce command, run in a second
  worktree at `origin/main` `ed75b87`. It **fails on base** — prints `MISSING`,
  and invoking the command exits 127 — and passes here with a store path and
  exit 0. The gate itself is the assertion: `rainix-sol-single-contract` cannot
  be invoked at all on base.
- **Mutations applied:** the rev is the only semantic value in the diff.
  (1) rev → `f22d4dc` is exactly the base state and the check reports
  `MISSING`/127 — killed by the discriminating test. (2) rev → `53e96a7` (CI's
  `RAINIX_SHA`) would also make the presence check green, so presence alone
  does not pin *which* rev; that mutant is not killed by any test and is not
  meant to be — the choice between `main` and `RAINIX_SHA` is the maintainer
  ruling recorded on #30, not a property this repo can assert. What is asserted
  instead is that `flake.nix` carries no rev at all, which is what that ruling
  requires and what a `flake.nix` diff of zero lines shows.
  (3) hand-merging the lock instead of regenerating it would resurrect the
  `rain` subtree — killed by the post-merge node-count/root-input check above
  (21 nodes, one `rainix`).
- **Oracle:** nix itself and the base worktree, not this change's own output.
  The rev move is what `nix flake lock --update-input rainix` printed; the
  toolchain-non-movement claim is nix store paths, which are hashes of the
  closure and not something this PR can assert about itself; the environmental
  failures are read from forge's own `[FAIL: …]` reason strings rather than
  inferred from a count; `rainix-sol-single-contract`'s existence in rainix
  `8af258f` is read from rainix's `flake.nix` at that rev, and its use in CI
  from rainix's `.github/workflows/rainix-sol-static.yaml` at `main`.
- **Category check:** #28 asks for one thing — the dev shell must provide
  `rainix-sol-single-contract` so the documented static gate runs locally — and
  states one non-goal, the unused `rain` input (#29, landed separately as #31,
  merged in here and not otherwise touched). No docs change is needed:
  `57618df` already corrected `README.md` and `CLAUDE.md`, and both describe a command
  that exists. No Solidity is in this diff, so no Solidity mutation testing
  applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
