### PR TITLE
test(env): hold both `DEPLOYMENT_SUITE` values in one test, not two

### DIFF
--- a/test/src/abstract/RainDeployBroadcast.t.sol
+++ b/test/src/abstract/RainDeployBroadcast.t.sol
@@ -37,8 +37,9 @@ contract RainDeployBroadcastTest is Test {
     /// variable, and this contract was exactly that until it was seen losing
     /// the race: the unset case resolved the `address-registry` the other test
     /// had written. Sequenced inside one test the two values cannot interleave,
-    /// and every write to that variable in this repo is now the one below,
-    /// after the only read that needs it absent.
+    /// and every `vm.setEnv` in this repo is now one of the two below — with
+    /// the write to `DEPLOYMENT_SUITE` after the only read that needs it
+    /// absent, so there is no write left for another test to observe.
     ///
     /// ## Unset first, and genuinely unset
     ///
@@ -61,17 +62,27 @@ contract RainDeployBroadcastTest is Test {
     ///
     /// ## Both before the key
     ///
-    /// `DEPLOYMENT_KEY` is deliberately unset. `vm.envUint` reverts on an unset
-    /// variable, so were the key read first, either half would fail on the
-    /// missing key — and a mistyped suite would send the deployer after the
-    /// wrong thing entirely.
+    /// `DEPLOYMENT_KEY` is set to something `vm.envUint` cannot parse, and that
+    /// unreadability is what makes the ordering observable: a suite failure
+    /// while the key is garbage is the outcome that says the key had not been
+    /// read yet, and a mistyped suite that failed on the key instead would send
+    /// the deployer after the wrong thing entirely.
+    ///
+    /// Set rather than absent, because absence is not this test's to give.
+    /// `rainix-sol-test` exports `DEPLOYMENT_KEY` from the org's deploy secret
+    /// onto the job that runs this suite, so a test that assumed it unset
+    /// asserted the ordering only in a bare shell — and a key that PARSES makes
+    /// both orderings produce the same revert, so it would assert nothing about
+    /// ordering in the one place the suite actually runs.
     function testRunSelectsTheSuiteFromTheEnvBeforeTheKeyAndNeverDefaults() external {
-        // Both absences are inputs, so they are asserted rather than assumed: a
-        // variable set outside this test reports itself by name here instead of
-        // as a surprising revert payload, or as an ordering this no longer
-        // discriminates.
+        // `DEPLOYMENT_SUITE` has to be ABSENT and no cheatcode makes it so, so
+        // the precondition is asserted: a value set outside this test reports
+        // itself by name here rather than as a surprising revert payload.
         assertFalse(vm.envExists("DEPLOYMENT_SUITE"));
-        assertFalse(vm.envExists("DEPLOYMENT_KEY"));
+        // `DEPLOYMENT_KEY` is asserted about by nothing, because this test SETS
+        // it. It only has to be unparseable, and a value it writes is a value
+        // no CI job's secret can change.
+        vm.setEnv("DEPLOYMENT_KEY", "not a private key");
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/src/abstract/RainDeployBroadcast.t.sol
+++ b/test/src/abstract/RainDeployBroadcast.t.sol
@@ -26,33 +26,68 @@ contract RainDeployBroadcastTest is Test {
         sDeploy = new ExampleDeploy();
     }
 
-    /// A mistyped suite MUST fail naming every valid suite, and MUST do so
-    /// before `DEPLOYMENT_KEY` is read. `DEPLOYMENT_KEY` is deliberately unset
-    /// here: if the key were read first, this would fail on the missing key and
-    /// send the reader after the wrong thing entirely.
-    function testRunUnknownSuiteRevertsBeforeReadingTheKey() external {
+    /// The suite comes from `DEPLOYMENT_SUITE`, an unset one is no suite rather
+    /// than a default, and both answers are reached before `DEPLOYMENT_KEY` is
+    /// read.
+    ///
+    /// ONE test for both values, because `vm.setEnv` writes the forge PROCESS'
+    /// environment. It is scoped to neither a test nor a contract, nothing
+    /// unsets or restores it, and forge runs tests concurrently — so two tests
+    /// holding two values for one variable is two tests racing over one
+    /// variable, and this contract was exactly that until it was seen losing
+    /// the race: the unset case resolved the `address-registry` the other test
+    /// had written. Sequenced inside one test the two values cannot interleave,
+    /// and every write to that variable in this repo is now the one below,
+    /// after the only read that needs it absent.
+    ///
+    /// ## Unset first, and genuinely unset
+    ///
+    /// `vm.setEnv("DEPLOYMENT_SUITE", "")` would set a variable that is PRESENT
+    /// and empty, which never reaches `vm.envOr`'s default — so it would pass
+    /// just as happily if that default became a real suite key, and a deploy
+    /// that picks something when told nothing is how the wrong contract reaches
+    /// a chain. Only an absent variable exercises the default, and absent is a
+    /// state no cheatcode restores, so this half runs before anything sets it.
+    ///
+    /// That the reported key is empty rather than a suite is what says there is
+    /// no default; `RainDeploySuitesBaseTest.testEmptySuiteIsUnknown` is what
+    /// says an empty key is unknown.
+    ///
+    /// ## Then a suite nobody declared
+    ///
+    /// A mistyped suite MUST fail naming every valid suite. The reported key is
+    /// the value of THAT variable under THAT name, which is what a set value
+    /// distinct from the default proves and an unset one cannot.
+    ///
+    /// ## Both before the key
+    ///
+    /// `DEPLOYMENT_KEY` is deliberately unset. `vm.envUint` reverts on an unset
+    /// variable, so were the key read first, either half would fail on the
+    /// missing key — and a mistyped suite would send the deployer after the
+    /// wrong thing entirely.
+    function testRunSelectsTheSuiteFromTheEnvBeforeTheKeyAndNeverDefaults() external {
+        // Both absences are inputs, so they are asserted rather than assumed: a
+        // variable set outside this test reports itself by name here instead of
+        // as a surprising revert payload, or as an ordering this no longer
+        // discriminates.
+        assertFalse(vm.envExists("DEPLOYMENT_SUITE"));
+        assertFalse(vm.envExists("DEPLOYMENT_KEY"));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                UnknownDeploymentSuite.selector,
+                "",
+                "address-registry-0-0-1, second-address, address-registry-candidate"
+            )
+        );
+        sDeploy.run();
+
         vm.setEnv("DEPLOYMENT_SUITE", "address-registry");
 
         vm.expectRevert(
             abi.encodeWithSelector(
                 UnknownDeploymentSuite.selector,
                 "address-registry",
-                "address-registry-0-0-1, second-address, address-registry-candidate"
-            )
-        );
-        sDeploy.run();
-    }
-
-    /// An unset `DEPLOYMENT_SUITE` MUST be an unknown suite rather than a
-    /// default. A deploy that picks something when told nothing is how the
-    /// wrong contract reaches a chain.
-    function testRunUnsetSuiteReverts() external {
-        vm.setEnv("DEPLOYMENT_SUITE", "");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                UnknownDeploymentSuite.selector,
-                "",
                 "address-registry-0-0-1, second-address, address-registry-candidate"
             )
         );


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/36.

`vm.setEnv` writes the forge PROCESS' environment. It is scoped to neither a
test nor a contract, no cheatcode unsets or restores it, and forge runs tests
concurrently — so two tests holding two values for one variable is two tests
racing over one variable. `RainDeployBroadcastTest` was exactly that, and was
seen losing the race: the unset case resolved the `address-registry` the other
test had written.

```
[FAIL: Error != expected error:
 UnknownDeploymentSuite("address-registry", "address-registry-0-0-1, second-address, address-registry-candidate")
 != UnknownDeploymentSuite("", "address-registry-0-0-1, second-address, address-registry-candidate")]
 testRunUnsetSuiteReverts()
```

## The fix

The two values are sequenced inside ONE test, which is the only ordering forge
guarantees, and every `vm.setEnv` in the repo is now in that one test — the
`DEPLOYMENT_SUITE` write after the only read that needs it absent, so there is no
write left for another test to observe. Nothing else in the repo reads
`DEPLOYMENT_SUITE` or `DEPLOYMENT_KEY`: the only reader is `run()`, and the only
caller of `run()` is this test.

There is no smaller fix. Foundry offers no scoped or restorable env: `setEnv` is
`std::env::set_var` on the process, and `unsetEnv` does not exist. Making the
value injectable instead would remove the only assertion that the value comes
from a variable of THAT name (killed as M2 below), and serialising the suite with
`--threads 1` would trade the whole suite's parallelism to leave the sharing in
place.

## The two variables are not the same problem

`DEPLOYMENT_SUITE` has to be genuinely ABSENT, and that is the assertion doing
the work. `vm.setEnv("DEPLOYMENT_SUITE", "")` set a variable that was PRESENT and
empty, so `vm.envOr`'s default was never reached and a default that silently
became a real suite key passed — the exact hazard that test's own comment names,
"a deploy that picks something when told nothing". Nothing in CI sets that
variable (checked: neither `rainix-sol-test` nor this repo's caller workflow), so
`assertFalse(vm.envExists("DEPLOYMENT_SUITE"))` holds and states the precondition
by name.

`DEPLOYMENT_KEY` is the opposite: absence is not this test's to give.
`rainix-sol-test` sets `DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}` on the job
that runs this suite, so it is present everywhere the test really runs. So the
test SETS it, to something `vm.envUint` cannot parse. That is a stronger oracle
than absence, not a weaker one: the ordering claim is "the suite was resolved
before the key was read", and a key that PARSES makes both orderings produce the
same revert — so under CI's own key, asserting absence would have discriminated
nothing about ordering even if it had passed. Unreadable-by-construction makes
M3 die in every environment.

## Mutation matrix

`forge test --match-path test/src/abstract/RainDeployBroadcast.t.sol --match-test testRunSelectsTheSuiteFromTheEnvBeforeTheKeyAndNeverDefaults`,
run under each ambient `DEPLOYMENT_KEY` state the suite meets — unset (bare
shell), set to a valid key (CI with the secret populated), set to empty (CI with
the secret absent, which still exports the variable):

| # | Mutation in `src/abstract/RainDeployBroadcast.sol` | key unset | key valid | key empty |
|---|---|---|---|---|
| M0 | none (baseline) | **PASS** | **PASS** | **PASS** |
| M1 | `envOr` default `""` → `"address-registry-0-0-1"` | **FAIL** | **FAIL** | **FAIL** |
| M2 | `"DEPLOYMENT_SUITE"` → `"DEPLOYMENT_SUIT"` | **FAIL** | **FAIL** | **FAIL** |
| M3 | `envUint("DEPLOYMENT_KEY")` moved above `suiteByName(...)` | **FAIL** | **FAIL** | **FAIL** |

M1 and M3 fail with `Error != expected error: vm.envUint: failed parsing
$DEPLOYMENT_KEY as type uint256: parser error != UnknownDeploymentSuite("", ...)`;
M2 with `UnknownDeploymentSuite("", ...) != UnknownDeploymentSuite("address-registry", ...)`.

Two more results from the same matrix:

- M1 run against the tests as they were BEFORE this PR: `testRunUnknownSuiteRevertsBeforeReadingTheKey`
  and `testRunUnsetSuiteReverts` both **PASS**. A deploy script that picks a real
  suite when told nothing survived the old suite; it is killed here.
- The first commit on this branch, run under a set `DEPLOYMENT_KEY`, reproduces
  the CI red exactly — `[FAIL: assertion failed] ... (gas: 3980)`, the same gas
  figure as [the failing job](https://github.com/rainlanguage/rain.deploy/actions/runs/31822511218/job/94838873467)
  — and passes in a bare shell. That is the whole of the CI failure, confirmed
  rather than assumed: the `-vvv` trace shows both `VM::envExists` calls followed
  by one `VM::assertFalse(true)`, i.e. the `DEPLOYMENT_KEY` assertion.

`forge fmt --check` passes. `forge test --no-match-contract Chain` on this branch,
run with `DEPLOYMENT_KEY` set as CI sets it, is 92 passed / 38 failed where all 38
are `vm.createSelectFork: environment variable *_RPC_URL not found` in
`LibRainDeployTest` — what #32 is about and #34 fixes. This branch changes one
file and it is not that one.

## QA

- **Discriminating tests**: `testRunSelectsTheSuiteFromTheEnvBeforeTheKeyAndNeverDefaults`
  — passes unmutated (M0) and fails under each of M1, M2 and M3, in all three
  ambient `DEPLOYMENT_KEY` states (unset, valid, empty): 12 runs, one per cell of
  the matrix above. Each is its own `forge test --match-path test/src/abstract/RainDeployBroadcast.t.sol
  --match-test <name>` with the `[PASS]` / `[FAIL: ...]` line captured, so every
  cell is a run that actually selected and executed the test rather than a filter
  matching nothing. The two tests this PR does not touch —
  `testDeployNetworksDefaultsToSupportedNetworks`, `testSelectedSuiteCarriesTheRecordedPins`
  — are unchanged.
- **Mutations applied** (all in `src/abstract/RainDeployBroadcast.sol`, the code
  under test; killer is the test above in every case, in every environment):
  - M1 — `vm.envOr("DEPLOYMENT_SUITE", string(""))` → `string("address-registry-0-0-1")`
    → KILLED: `vm.envUint: failed parsing $DEPLOYMENT_KEY as type uint256 != UnknownDeploymentSuite("", ...)`.
    **This mutant SURVIVES the pre-PR tests** — `testRunUnknownSuiteRevertsBeforeReadingTheKey`
    and `testRunUnsetSuiteReverts` both PASS under it. That gap is what the new
    test closes.
  - M2 — `"DEPLOYMENT_SUITE"` → `"DEPLOYMENT_SUIT"` → KILLED:
    `UnknownDeploymentSuite("", ...) != UnknownDeploymentSuite("address-registry", ...)`.
  - M3 — `uint256 deployerPrivateKey = vm.envUint("DEPLOYMENT_KEY");` moved above
    the `suiteByName(...)` line → KILLED: `vm.envUint: failed parsing $DEPLOYMENT_KEY as type uint256 != UnknownDeploymentSuite("", ...)`.
    Killed under a VALID ambient key too, which is the case that matters: this
    mutant is invisible to any test that lets a parseable key reach `envUint`,
    because then both orderings revert identically.
- **Oracle**: the workflow's contract with the script, not the implementation.
  `Manual sol artifacts` hands the script a suite key as `DEPLOYMENT_SUITE` and key
  custody as `DEPLOYMENT_KEY`, so the expected behaviour is fixed independently of
  the code: the key the caller passed is the key reported back, passing no suite
  selects no suite, and neither answer requires a usable private key. The
  valid-suite list in the expected payload is the fixture's own declaration
  (`ExampleDeploySuites`), asserted separately by
  `RainDeploySuitesBaseTest.testSuiteNamesIsTheRegistry`.
- **Category check**: #36 asks for the shared `vm.setEnv` state removed without
  either assertion getting weaker, and names the three behaviours the result must
  still discriminate — the `envOr` default becoming a suite key, the variable name
  changing, and the key being read before the suite. Covered by M1, M2 and M3
  respectively, plus the sharing itself: every `vm.setEnv` in the repo is in this
  one test, with the `DEPLOYMENT_SUITE` write after the only read that needs it
  absent.
