### PR TITLE
docs: drop the `--no-match-contract Chain` selection nobody runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,7 @@ POLYGON_RPC_URL=https://polygon-bor-rpc.publicnode.com
 All five are needed: `RainDeployVerifyChain` forks every network in
 `supportedNetworks()`, so a missing or rate-limited endpoint fails it. Those
 failures are `vm.createSelectFork` errors, distinct from the
-`NotDeployedOnNetwork` a reachable network raises, and the snapshot contracts
-run regardless: `forge test --no-match-contract Chain`.
+`NotDeployedOnNetwork` a reachable network raises.
 
 These are referenced in `foundry.toml` under `[rpc_endpoints]`.
 
@@ -270,8 +269,7 @@ can set. Group 3 is what makes group 4's scope complete — a release group 4 is
 never handed is a release it cannot fail on.
 
 Group 4 lives in its own contract so an unreachable RPC endpoint fails only it,
-never the snapshot assertions — `forge test --no-match-contract Chain` is the
-whole snapshot gate, and nothing reachable from those contracts forks anything.
+never the snapshot assertions, and a failure names which of the two it was.
 
 A single recorded code hash per version can only be true if the runtime code is
 the same on every network, so a constructor reading `block.chainid` or similar

--- a/test/src/concrete/AddressRegistryDeployChain.t.sol
+++ b/test/src/concrete/AddressRegistryDeployChain.t.sol
@@ -20,9 +20,8 @@ import {AddressRegistryDeploySuites} from "../../../src/abstract/AddressRegistry
 /// consistent set of pins for a contract that exists nowhere passes every one
 /// of them. A green here would only mean nobody asked.
 ///
-/// It is a separate contract from `AddressRegistryDeploySnapshotTest`
-/// precisely so that it says this and nothing more: `forge test
-/// --no-match-contract Chain` still runs every snapshot assertion,
-/// whether the deployment is missing or the RPC endpoints are merely
-/// unreachable.
+/// It is a separate contract from `AddressRegistryDeploySnapshotTest` precisely
+/// so that it says this and nothing more: a missing deployment or an
+/// unreachable endpoint fails here alone, leaving every snapshot assertion to
+/// answer for itself.
 contract AddressRegistryDeployChainTest is AddressRegistryDeploySuites, RainDeployVerifyChain {}


### PR DESCRIPTION
`forge test --no-match-contract Chain` was documented in three places as a way to run the suite without endpoints. Nothing invokes it.

- no CI step, no script, no flake package, no Makefile
- rainix CI runs `forge test -vvv`, the whole suite, forks and all
- it appears in my own session history only in the two sessions spent building and checking it

Documenting a capability with no caller creates work to keep it true — which is what https://github.com/rainlanguage/rain.deploy/pull/34 turned into: an 800-line test split serving a command nobody runs.

## What is removed

Three references. Nothing else.

| site | was |
| --- | --- |
| `CLAUDE.md` RPC section | "and the snapshot contracts run regardless: `forge test --no-match-contract Chain`" |
| `CLAUDE.md` group 4 | "`forge test --no-match-contract Chain` is the whole snapshot gate" |
| `AddressRegistryDeployChain.t.sol` natspec | "`forge test --no-match-contract Chain` still runs every snapshot assertion" |

## What survives

The design each site was attached to is real and stays stated: group 4 lives in its own contract so an unreachable endpoint fails there and not on the snapshot assertions. That separation is a property of the contract split, not of any command.

## QA

- Discriminating tests: n/a — comment and markdown only, no executable line changes and no behaviour to assert. The differential check is `git grep -- 'no-match-contract'`, which returns three hits on `main` and nothing on this branch; it fails on base by construction.
- Mutations applied: n/a — the diff contains no executable line to mutate. `forge fmt --check` exits 0, which is what establishes the edited natspec still parses.
- Oracle: the absence of callers, established independently of this change — grepping the repo for the string across yaml/yml/toml/sh/nix/Makefile returns only self-referential prose, and `rainlanguage/rainix/.github/workflows/rainix-sol-test.yaml` runs `forge test -vvv` with no contract filter.
- Category check: the ask was to remove this part of the docs. All three sites are removed, not only the one that prompted it. The contract separation the sites described is deliberately kept, because it is a property of the code rather than of the command.

Closes nothing. https://github.com/rainlanguage/rain.deploy/issues/32 stays open for the RPC failures, which this does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
