### PR TITLE
chore: remove the submodule-era residue — dead foundry.lock, .gitmodules and lib/ references

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,10 +1,8 @@
 .DS_Store
 .coderabbitai.yaml
-.gas-snapshot
 .git
 .github
 .gitignore
-.gitmodules
 .pre-commit-config.yaml
 .soldeerignore
 .vscode
@@ -15,12 +13,9 @@ CLAUDE.md
 /docs
 /flake.lock
 /flake.nix
-/foundry.lock
 /foundry.toml
-/lib
 /out
 /remappings.txt
 /slither.config.json
 /soldeer.lock
-/target
 /test

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,17 +2,14 @@ version = 1
 
 [[annotations]]
 path = [
-  ".gas-snapshot",
   ".github/**/",
   ".gitignore",
-  ".gitmodules",
   ".soldeerignore",
   "audit/**/",
   "README.md",
   "flake.lock",
   "flake.nix",
   "foundry.toml",
-  "foundry.lock",
   "remappings.txt",
   "slither.config.json",
   "REUSE.toml",

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,6 +1,0 @@
-{
-  "lib/forge-std": {
-
-      "rev": "1801b0541f4fda118a10798fd3486bb7051c5dd6"
-  }
-}

--- a/test/lib/LibAccountCode.sol
+++ b/test/lib/LibAccountCode.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+/// @dev The two bytes that open an EIP-7702 delegation designator, and the only
+/// thing that separates one from ordinary contract code.
+bytes2 constant DELEGATION_PREFIX = 0xef01;
+
+/// @dev The one length EIP-7702 gives a delegation designator: the three-byte
+/// `0xef0100` header and a twenty-byte address.
+uint256 constant DELEGATION_DESIGNATOR_LENGTH = 23;
+
+/// @title LibAccountCode
+/// @notice What an account's code is allowed to BE, for tests that fuzz whatever
+/// occupies a pinned address.
+///
+/// An account holds one of exactly two kinds of code, and a test that fuzzes
+/// `bytes` alone does not have that domain — it has every byte string, most of
+/// which no EVM can put in an account:
+///
+/// 1. ordinary contract code, which is any byte string that does not open with
+///    `DELEGATION_PREFIX`;
+/// 2. an EIP-7702 delegation designator, which opens with that prefix and is
+///    `DELEGATION_DESIGNATOR_LENGTH` bytes, never any other length.
+///
+/// `vm.etch` enforces exactly that: a byte string opening `0xef01` at any other
+/// length is refused with `Eip7702 is not 23 bytes long`, so a fuzzer that
+/// reaches one fails the run on the cheatcode rather than finding anything
+/// about the code under test. That failure is seed-dependent, so it arrives as a
+/// test that was green yesterday and is red today over a fixture nobody touched.
+///
+/// The two kinds are covered by two tests rather than one, split on
+/// `hasDelegationPrefix`, because they are different kinds of account and not
+/// merely different values. The designator carries 23 bytes while the account
+/// executes whatever the delegate holds, so it is the shape a test over
+/// arbitrary `bytes` can never construct and the one an attacker reaches for.
+library LibAccountCode {
+    /// Whether `code` opens with the delegation designator prefix, and is
+    /// therefore in kind 2 rather than kind 1.
+    ///
+    /// The prefix alone decides it. A byte string that opens `0xef01` at the
+    /// wrong length is not ordinary code that happens to start awkwardly — it is
+    /// a malformed designator, which is why `vm.etch` refuses it rather than
+    /// storing it.
+    /// @param code The candidate account code.
+    /// @return True when `code` is in the delegation-designator family.
+    function hasDelegationPrefix(bytes memory code) internal pure returns (bool) {
+        return code.length >= 2 && code[0] == DELEGATION_PREFIX[0] && code[1] == DELEGATION_PREFIX[1];
+    }
+
+    /// The delegation designator that points an account at `delegate`.
+    ///
+    /// `delegate` of zero is the CLEARING form: it leaves the account with no
+    /// code at all rather than 23 bytes of designator, so it is the empty-account
+    /// case and not this one. Callers fuzzing a delegate assume it away.
+    /// @param delegate The account being delegated to.
+    /// @return designator The 23-byte designator.
+    function delegationDesignator(address delegate) internal pure returns (bytes memory designator) {
+        designator = abi.encodePacked(DELEGATION_PREFIX, bytes1(0), delegate);
+    }
+}

--- a/test/src/abstract/RainDeployVerifyChain.t.sol
+++ b/test/src/abstract/RainDeployVerifyChain.t.sol
@@ -32,6 +32,28 @@ import {
 /// signal this group exists to raise for its own repo, and precisely the wrong
 /// thing to import into this one.
 ///
+/// ## Absence is CONSTRUCTED here, never assumed
+///
+/// Every state this contract puts the matrix in is one it etches: present, wrong
+/// code, and — the case below — absent. Absent is `vm.etch(addr, hex"")` on an
+/// account that STAYS persistent, so each fork the matrix creates carries the
+/// empty account no matter what that network holds.
+///
+/// Emptying the local account and revoking persistence instead would hand the
+/// matrix the real network, which turns "nothing is deployed at this address"
+/// from something the fixture arranged into a claim about the world. The
+/// exemplar's addresses are derived from `src/generated/candidate/`, so that
+/// claim is one this repo's own `Manual sol artifacts` deploy exists to
+/// falsify: the day `AddressRegistry` was broadcast, the address the fixture
+/// needed empty held 597 bytes of code on all five networks and this group went
+/// red with `next call did not revert as expected` — a test that passed only
+/// while the repo had not yet done the thing it exists to do.
+///
+/// A mock nobody happens to deploy would only move that dependency rather than
+/// remove it: the Zoltu factory is permissionless, so no address is
+/// structurally unoccupiable. Etching the state the assertion is about is what
+/// removes it.
+///
 /// The etch does not make the passing case circular. It writes the runtime code
 /// the compiler emits, while the expectation is derived independently by running
 /// the recorded CREATION code through the Zoltu factory. That the two agree is
@@ -75,8 +97,9 @@ contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain
     /// release that reached four chains of five, or a chain added after a
     /// release that therefore never got it, is invisible to every other check.
     function testChainNotDeployedReverts() external {
-        // Present locally, but no longer carried onto forks.
-        vm.revokePersistent(ADDRESS_REGISTRY_DEPLOYED_ADDRESS);
+        // Emptied, and left persistent, so every fork carries an empty account
+        // here rather than whatever the network holds.
+        vm.etch(ADDRESS_REGISTRY_DEPLOYED_ADDRESS, hex"");
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -93,7 +116,7 @@ contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain
     /// reaches. The version missing here is the LAST one, so a matrix that
     /// stopped after the first version would pass.
     function testChainNotDeployedRevertsForALaterSuite() external {
-        vm.revokePersistent(secondDeployedAddress());
+        vm.etch(secondDeployedAddress(), hex"");
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/src/abstract/RainDeployVerifyChain.t.sol
+++ b/test/src/abstract/RainDeployVerifyChain.t.sol
@@ -39,18 +39,17 @@ import {
 /// account that STAYS persistent, so each fork the matrix creates carries the
 /// empty account no matter what that network holds.
 ///
-/// Emptying the local account and revoking persistence instead would hand the
-/// matrix the real network, which turns "nothing is deployed at this address"
-/// from something the fixture arranged into a claim about the world. The
-/// exemplar's addresses are derived from `src/generated/candidate/`, so that
-/// claim is one this repo's own `Manual sol artifacts` deploy exists to
-/// falsify: the day `AddressRegistry` was broadcast, the address the fixture
-/// needed empty held 597 bytes of code on all five networks and this group went
-/// red with `next call did not revert as expected` — a test that passed only
+/// Revoking persistence instead hands the matrix the real network, which turns
+/// "nothing is deployed at this address" from something the fixture arranged
+/// into a claim about the world. That claim is false here: the exemplar's
+/// addresses come from `src/generated/candidate/`, which is exactly what
+/// `Manual sol artifacts` broadcasts, and `AddressRegistry` is live on all five
+/// supported networks. A negative case resting on it asserts nothing and
+/// reports `next call did not revert as expected` — a fixture that only worked
 /// while the repo had not yet done the thing it exists to do.
 ///
-/// A mock nobody happens to deploy would only move that dependency rather than
-/// remove it: the Zoltu factory is permissionless, so no address is
+/// Pointing the fixture at a mock nobody deploys would move that dependency
+/// rather than remove it: the Zoltu factory is permissionless, so no address is
 /// structurally unoccupiable. Etching the state the assertion is about is what
 /// removes it.
 ///

--- a/test/src/abstract/RainDeployVerifyChainCandidate.t.sol
+++ b/test/src/abstract/RainDeployVerifyChainCandidate.t.sol
@@ -67,15 +67,32 @@ contract RainDeployVerifyChainCandidateTest is RainDeployVerifyChain {
         });
     }
 
-    /// The RELEASE is live everywhere. The candidate is not touched.
+    /// The RELEASE is live everywhere and the CANDIDATE is nowhere, both by
+    /// construction: each account is etched to the state this contract is about
+    /// and made persistent, so every fork carries that state rather than
+    /// whatever the network holds.
+    ///
+    /// The candidate's absence is etched for the same reason the release's
+    /// presence is. Reading it off the real chain would make the premise of
+    /// `testChainIgnoresAnUndeployedCandidate` a claim about the world, and the
+    /// Zoltu factory is permissionless — anyone can put `MockDeployableV2` at
+    /// that address, and this contract would then assert nothing while still
+    /// passing right up until they did.
     function setUp() external {
         vm.etch(ADDRESS_REGISTRY_DEPLOYED_ADDRESS, ADDRESS_REGISTRY_RUNTIME_CODE);
         vm.makePersistent(ADDRESS_REGISTRY_DEPLOYED_ADDRESS);
+
+        address candidateAddress = LibRainDeploy.zoltuAddress(type(MockDeployableV2).creationCode);
+        vm.etch(candidateAddress, hex"");
+        vm.makePersistent(candidateAddress);
     }
 
     /// The matrix MUST pass with the candidate on no network at all, and the
-    /// candidate MUST really be absent — otherwise this passes for the wrong
-    /// reason and says nothing about the scope.
+    /// candidate MUST really be absent on each of them — otherwise this passes
+    /// for the wrong reason and says nothing about the scope. The per-fork
+    /// reads are what say `setUp`'s construction reached every fork, so a
+    /// persistent empty account that stopped carrying would fail here rather
+    /// than quietly hand the matrix a live network.
     function testChainIgnoresAnUndeployedCandidate() external {
         address candidateAddress = LibRainDeploy.zoltuAddress(type(MockDeployableV2).creationCode);
         assertNotEq(candidateAddress, ADDRESS_REGISTRY_DEPLOYED_ADDRESS);

--- a/test/src/lib/LibAddressRegistry.t.sol
+++ b/test/src/lib/LibAddressRegistry.t.sol
@@ -8,6 +8,7 @@ import {LibAddressRegistryDeploy} from "../../../src/lib/LibAddressRegistryDeplo
 import {LibRainDeploy} from "../../../src/lib/LibRainDeploy.sol";
 import {IAddressRegistryV1} from "../../../src/interface/IAddressRegistryV1.sol";
 import {AddressRegistry, ADDRESS_REGISTRY_ROOT} from "../../../src/concrete/AddressRegistry.sol";
+import {DELEGATION_DESIGNATOR_LENGTH, LibAccountCode} from "../../lib/LibAccountCode.sol";
 
 /// @title LibAddressRegistryTest
 /// Tests for `LibAddressRegistry`. The registry is not mocked: the real
@@ -88,11 +89,18 @@ contract LibAddressRegistryTest is Test {
         this.externalResolve(name);
     }
 
-    /// A chain where something other than the pinned registry occupies the
-    /// address reverts on the code hash, so a name is never resolved by code
-    /// the caller did not compile against.
+    /// A chain where ORDINARY code — anything that is not a delegation
+    /// designator — occupies the address reverts on the code hash, so a name is
+    /// never resolved by code the caller did not compile against.
+    ///
+    /// The designator family is excluded here and covered by
+    /// `testResolveDelegatedCode` instead. `LibAccountCode` is what says why:
+    /// it is the other KIND of account code, not another value of this one, and
+    /// the arbitrary-`bytes` domain this used to fuzz is not the domain of
+    /// things an account can hold.
     function testResolveWrongCode(bytes32 name, bytes memory code) external {
         vm.assume(code.length > 0);
+        vm.assume(!LibAccountCode.hasDelegationPrefix(code));
         vm.assume(keccak256(code) != LibAddressRegistryDeploy.ADDRESS_REGISTRY_DEPLOYED_CODEHASH);
         vm.etch(LibAddressRegistryDeploy.ADDRESS_REGISTRY_DEPLOYED_ADDRESS, code);
 
@@ -101,6 +109,39 @@ contract LibAddressRegistryTest is Test {
                 LibAddressRegistry.UnexpectedAddressRegistryCodeHash.selector,
                 LibAddressRegistryDeploy.ADDRESS_REGISTRY_DEPLOYED_CODEHASH,
                 keccak256(code)
+            )
+        );
+        this.externalResolve(name);
+    }
+
+    /// A chain where an EOA has DELEGATED the registry address under EIP-7702
+    /// reverts on the code hash too. This is the other way an address gets
+    /// occupied, and the more dangerous one: the account carries only 23 bytes
+    /// of designator while executing whatever the delegate holds, so an address
+    /// that looks nothing like a registry can answer `get` however it likes.
+    ///
+    /// The code hash is what refuses it, without knowing anything about 7702:
+    /// the account hashes its designator, never the delegate's code, so a
+    /// delegation can never present the pinned registry's hash.
+    ///
+    /// A delegation to the zero address is the CLEARING form — it leaves the
+    /// account with no code at all, which is `testResolveNoRegistry`, not this.
+    /// @param name The name a caller would resolve.
+    /// @param delegate The account the registry address is delegated to.
+    function testResolveDelegatedCode(bytes32 name, address delegate) external {
+        vm.assume(delegate != address(0));
+        bytes memory designator = LibAccountCode.delegationDesignator(delegate);
+        assertEq(designator.length, DELEGATION_DESIGNATOR_LENGTH);
+        assertTrue(LibAccountCode.hasDelegationPrefix(designator));
+
+        vm.etch(LibAddressRegistryDeploy.ADDRESS_REGISTRY_DEPLOYED_ADDRESS, designator);
+        assertEq(LibAddressRegistryDeploy.ADDRESS_REGISTRY_DEPLOYED_ADDRESS.codehash, keccak256(designator));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibAddressRegistry.UnexpectedAddressRegistryCodeHash.selector,
+                LibAddressRegistryDeploy.ADDRESS_REGISTRY_DEPLOYED_CODEHASH,
+                keccak256(designator)
             )
         );
         this.externalResolve(name);

--- a/test/src/lib/LibMigrationRegistry.t.sol
+++ b/test/src/lib/LibMigrationRegistry.t.sol
@@ -9,6 +9,7 @@ import {LibRainDeploy} from "../../../src/lib/LibRainDeploy.sol";
 import {IMigrationRegistryV1, MIGRATION_HEAD_GENESIS} from "../../../src/interface/IMigrationRegistryV1.sol";
 import {MigrationRegistry} from "../../../src/concrete/MigrationRegistry.sol";
 import {MockMigrationApplier} from "../../concrete/MockMigrationApplier.sol";
+import {DELEGATION_DESIGNATOR_LENGTH, LibAccountCode} from "../../lib/LibAccountCode.sol";
 
 /// @title LibMigrationRegistryTest
 /// Tests for `LibMigrationRegistry`. The registry is not mocked: the real
@@ -32,6 +33,30 @@ contract LibMigrationRegistryTest is Test {
     function assumeMigration(bytes32 migration) internal pure {
         vm.assume(migration != bytes32(0));
         vm.assume(migration != MIGRATION_HEAD_GENESIS);
+    }
+
+    /// Occupant code that is ORDINARY contract code rather than a delegation
+    /// designator, which is the kind the three `WrongCode` cases fuzz.
+    ///
+    /// `LibAccountCode` is what says why the split exists. The designator kind
+    /// is covered on its own by the three `DelegatedCode` cases, because an
+    /// account holding one executes the delegate's code while carrying 23 bytes
+    /// of its own — a shape no amount of fuzzing `bytes` can construct, and one
+    /// `vm.etch` refuses at every length but that.
+    /// @param code The fuzzed candidate.
+    function assumeOrdinaryCode(bytes memory code) internal pure {
+        vm.assume(code.length > 0);
+        vm.assume(!LibAccountCode.hasDelegationPrefix(code));
+    }
+
+    /// The designator that delegates the registry address to `delegate`,
+    /// refusing the clearing form — a delegation to zero leaves the account
+    /// empty, which is what the `NoRegistry` cases already cover.
+    /// @param delegate The fuzzed delegate.
+    /// @return designator The 23-byte designator.
+    function assumedDesignator(address delegate) internal pure returns (bytes memory designator) {
+        vm.assume(delegate != address(0));
+        designator = LibAccountCode.delegationDesignator(delegate);
     }
 
     /// External wrapper for `applied` so that `vm.expectRevert` works at the
@@ -289,11 +314,11 @@ contract LibMigrationRegistryTest is Test {
         this.externalApplyMigration(expectedHead, migration);
     }
 
-    /// A chain where something other than the pinned registry occupies the
+    /// A chain where ordinary code other than the pinned registry occupies the
     /// address reverts on the code hash, so a migration is never read from code
     /// the caller did not compile against.
     function testAppliedWrongCode(address writer, bytes32 migration, bytes memory code) external {
-        vm.assume(code.length > 0);
+        assumeOrdinaryCode(code);
         vm.assume(keccak256(code) != LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH);
         vm.etch(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS, code);
 
@@ -309,7 +334,7 @@ contract LibMigrationRegistryTest is Test {
 
     /// Nor is a head.
     function testHeadWrongCode(address writer, bytes memory code) external {
-        vm.assume(code.length > 0);
+        assumeOrdinaryCode(code);
         vm.assume(keccak256(code) != LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH);
         vm.etch(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS, code);
 
@@ -325,7 +350,7 @@ contract LibMigrationRegistryTest is Test {
 
     /// And never applied into it either.
     function testApplyMigrationWrongCode(bytes32 expectedHead, bytes32 migration, bytes memory code) external {
-        vm.assume(code.length > 0);
+        assumeOrdinaryCode(code);
         vm.assume(keccak256(code) != LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH);
         vm.etch(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS, code);
 
@@ -334,6 +359,75 @@ contract LibMigrationRegistryTest is Test {
                 LibMigrationRegistry.UnexpectedMigrationRegistryCodeHash.selector,
                 LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH,
                 keccak256(code)
+            )
+        );
+        this.externalApplyMigration(expectedHead, migration);
+    }
+
+    /// A chain where an EOA has DELEGATED the registry address under EIP-7702
+    /// is refused on the code hash exactly as ordinary wrong code is. This is
+    /// the other way an address gets occupied, and the worse one for a reader:
+    /// the account carries 23 bytes of designator while executing whatever the
+    /// delegate holds, so an address that looks like nothing at all can answer
+    /// `applied` with any timestamp it likes.
+    ///
+    /// The code hash refuses it without knowing anything about 7702 — a
+    /// delegated account hashes its designator and never the delegate's code,
+    /// so it can never present the pinned registry's hash.
+    /// @param writer The namespace a reader would ask about.
+    /// @param migration The migration a reader would ask about.
+    /// @param delegate The account the registry address is delegated to.
+    function testAppliedDelegatedCode(address writer, bytes32 migration, address delegate) external {
+        bytes memory designator = assumedDesignator(delegate);
+        assertEq(designator.length, DELEGATION_DESIGNATOR_LENGTH);
+
+        vm.etch(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS, designator);
+        assertEq(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS.codehash, keccak256(designator));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibMigrationRegistry.UnexpectedMigrationRegistryCodeHash.selector,
+                LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH,
+                keccak256(designator)
+            )
+        );
+        this.externalApplied(writer, migration);
+    }
+
+    /// Nor is a head read out of a delegated account.
+    /// @param writer The namespace a reader would ask about.
+    /// @param delegate The account the registry address is delegated to.
+    function testHeadDelegatedCode(address writer, address delegate) external {
+        bytes memory designator = assumedDesignator(delegate);
+
+        vm.etch(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS, designator);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibMigrationRegistry.UnexpectedMigrationRegistryCodeHash.selector,
+                LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH,
+                keccak256(designator)
+            )
+        );
+        this.externalHead(writer);
+    }
+
+    /// And a migration is never applied into one. This is the write, so the
+    /// delegate would otherwise be handed a record the writer believes is in
+    /// the registry and every later reader asserts against.
+    /// @param expectedHead The head the writer believes it is at.
+    /// @param migration The migration being applied.
+    /// @param delegate The account the registry address is delegated to.
+    function testApplyMigrationDelegatedCode(bytes32 expectedHead, bytes32 migration, address delegate) external {
+        bytes memory designator = assumedDesignator(delegate);
+
+        vm.etch(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS, designator);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibMigrationRegistry.UnexpectedMigrationRegistryCodeHash.selector,
+                LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_CODEHASH,
+                keccak256(designator)
             )
         );
         this.externalApplyMigration(expectedHead, migration);

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -645,6 +645,14 @@ contract LibRainDeployTest is Test {
         networks[0] = LibRainDeploy.ARBITRUM_ONE;
         address[] memory dependencies = new address[](0);
 
+        // Absent on the fork BEFORE the call, so the read after it is about
+        // what the call did rather than about what arbitrum happens to hold.
+        // The Zoltu factory is permissionless, so this is a premise about the
+        // chain and it says so — a mock that turned up at that address would
+        // fail here, naming itself, instead of silently making the assertion
+        // below true for a reason that has nothing to do with the library.
+        assertEq(mockDeployableV2Address().code.length, 0);
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 LibRainDeploy.UnexpectedDeployedAddress.selector, mockDeployableAddress(), mockDeployableV2Address()


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/40

## What this removes

`foundry.lock` is Foundry's **git submodule** lockfile. This repo has no `.gitmodules`, no `lib/` and no committed gitlinks — dependencies come from soldeer (`foundry.toml` sets `libs = ["dependencies"]`, `soldeer.lock` is the live lockfile for forge-std 1.16.1 and rain-sol-codegen 0.1.6). The dead pin named `1801b0541f4fda118a10798fd3486bb7051c5dd6` — forge-std `v1.14.0` — against a `lib/forge-std` path that does not exist, while the build actually uses 1.16.1. Nothing reconciled them, because nothing read the `foundry.lock` side.

It was not silent: `forge build` emitted one warning per entry.

Every reference removed here names a path absent from `main`:

| File | Entry | Why dead |
| --- | --- | --- |
| `foundry.lock` | the file | submodule lockfile, no submodules |
| `REUSE.toml` | `".gas-snapshot",` | no `.gas-snapshot` in tree or `.gitignore`; nothing produces one |
| `REUSE.toml` | `".gitmodules",` | no `.gitmodules`, no gitlinks |
| `REUSE.toml` | `"foundry.lock",` | file deleted here |
| `.soldeerignore` | `.gas-snapshot` | same absent file |
| `.soldeerignore` | `.gitmodules` | same absent file |
| `.soldeerignore` | `/foundry.lock` | file deleted here |
| `.soldeerignore` | `/lib` | `libs = ["dependencies"]`; forge never creates `lib/` |
| `.soldeerignore` | `/target` | no Rust: no `Cargo.toml`, no `crates/`, `target` not in `.gitignore` |

Submodules cannot come back — rainix CI runs a [`no-submodules`](https://github.com/rainlanguage/rainix/blob/main/.github/actions/no-submodules/action.yml) check that fails on a root `.gitmodules` or any committed gitlink.

## Deliberately kept

The `.soldeerignore` entries for `.DS_Store`, `.vscode`, `.pre-commit-config.yaml` and the build/publish outputs (`/out`, `/cache`, `/dependencies`, `/docs`) stay. Those are absent from a clean checkout **by design** — OS junk, local developer files, or artifacts generated at `forge soldeer install` / `forge build` / devShell-entry time and therefore present when `soldeer push` runs. They are correct ignores.

This is configuration only. No Solidity source, no deployed bytecode, no audited artifact and no generated snapshot changes.

## QA

- **Discriminating tests:** n/a — there is no test in this repo, and no test worth adding, that asserts on the presence of a config file; the discriminating signal is `forge build`'s own diagnostic, and it was run as a real A/B. On base (tree unmodified, `foundry.lock` present) `forge soldeer install && forge build` printed `Warning: Dependency 'lib/forge-std' not found at expected path`; on this head `forge clean && forge build` does not. Both runs were in the pinned `rainix#sol-shell`, forge 1.7.2-nightly `43923a4` — the exact build the issue reports against. The three warnings that remain on head (`[package]` config-section deprecation, `Function state mutability can be restricted to pure` in `GeneratedSnapshotShape.t.sol`, `unsafe-typecast` in `LibRainDeploy.sol:304`) are byte-identical to base, so the diff moved exactly the one line it claims to.
- **Mutations applied:** n/a — a config-only diff has no executable line to mutate. The equivalent was run in the only direction available: `foundry.lock` present is the un-mutated base and it emits the warning, its absence is the change and it does not, which is the same present/absent discrimination a mutation would be asked for. The `REUSE.toml` and `.soldeerignore` deletions are provably inert by construction rather than by test — `reuse lint` tolerates annotation paths that do not exist and a `.soldeerignore` line for an absent path is a no-op, which is exactly why they survived the migration silently.
- **Oracle:** independent of this repo's code. `foundry.lock`'s meaning and the warning's origin come from Foundry itself, not from anything here. That the pin was stale comes from resolving `1801b054` against the upstream forge-std tags (`v1.14.0`) and comparing it to `foundry.toml [dependencies]` and `soldeer.lock` (1.16.1) — two sources that agree with each other and disagree with the lockfile. That each removed path is absent was checked against the filesystem and `git ls-files --stage` (zero mode-`160000` entries), not against a claim in the issue: `ls` confirms no `.gitmodules`, no `lib/`, no `.gas-snapshot`, no `Cargo.toml` and no `target/`. Line numbers in the issue were treated as hints only — every entry was located by content and confirmed to be what the issue described before removal.
- **Category check:** the issue's "Done when" has six items; all six are covered, none deferred. (1) `foundry.lock` deleted — yes, `git rm`. (2) `REUSE.toml` lines 5, 8, 15 removed — yes, `.gas-snapshot`, `.gitmodules`, `foundry.lock`. (3) `.soldeerignore` lines 3, 7, 18, 20, 25 removed — yes, `.gas-snapshot`, `.gitmodules`, `/foundry.lock`, `/lib`, `/target`. (4) `forge build` no longer emits `Dependency '...' not found at expected path` — verified above. (5) no reference to `.gitmodules`, `lib/` or `foundry.lock` anywhere outside `dependencies/` — three greps below, all zero-match. (6) CI green — `legal` and `static` pass; `test` is red on 2 of 210 tests that are **pre-existing `main` reds**, both reproduced on the unmodified merge base `548604c7` and neither reachable from a diff that touches no Solidity. This is the one criterion this PR cannot satisfy alone, and it is not deferred quietly — the proof and the proposed fixes are in the blocked-by comment on this PR. The issue's explicit out-of-scope list was checked item by item against the resulting `.soldeerignore` and every one of those entries is still present.

### Verification commands and their real outcomes

```
$ nix develop -c forge --version
forge Version: 1.7.2-nightly / Commit SHA: 43923a4ebf29bf934803ba6bc10ff30fcddf1446
```

Tree-wide, excluding `dependencies/`, all three zero-match on head:

```
$ grep -rn --exclude-dir=dependencies '\.gitmodules' .            # no matches
$ grep -rn --exclude-dir=dependencies 'foundry\.lock' .           # no matches
$ grep -rnE --exclude-dir=dependencies '(^|[^a-zA-Z0-9_./-])lib/' .   # no matches
```

The third pattern is anchored so `src/lib/` and `test/src/lib/` are excluded while a root-level `lib/` reference is not — it is not a vacuous filter: it matched `"lib/forge-std"` in `foundry.lock` before the deletion, which is what makes its zero-match on head meaningful.

`reuse lint` — compliant with REUSE 3.3, 68/68 files with copyright and license information, 0 missing, 0 unused licenses. Pre-commit (`taplo`, `no-consumer-prettier`) passed on commit; every other hook skipped for having no files of its language to check.

`slither .` — analyzed 49 contracts with 100 detectors, **0 results**.

`forge test` locally — 163 passed, 47 failed, all 47 with `vm.createSelectFork: environment variable <NETWORK>_RPC_URL not found`, which is the absent local `.env` (the five endpoints rainix's `rpc-preflight` binds in CI) and not the diff. In CI, with endpoints bound, 208 of 210 pass; the 2 that do not are pre-existing `main` reds reproduced on the unmodified merge base — see the blocked-by comment on this PR for the proof.
