### PR TITLE
test(migration-registry): exercise the orderings the docstrings assert

### DIFF
--- a/test/src/concrete/MigrationRegistryApplyMigration.t.sol
+++ b/test/src/concrete/MigrationRegistryApplyMigration.t.sol
@@ -101,6 +101,59 @@ contract MigrationRegistryApplyMigrationTest is Test {
         assertEq(sRegistry.applied(writer, migration), 1);
     }
 
+    /// The zero timestamp is checked LAST, after every refusal that describes a
+    /// mistake in the call. Those are true whatever block the call lands in, so
+    /// a caller in a zero-timestamp block is told which of its arguments is
+    /// wrong rather than told to come back later — and only a caller whose
+    /// arguments are all right is told about the block, which is the one
+    /// refusal that goes away on its own.
+    function testApplyMigrationZeroTimestampCheckedLast(
+        address writer,
+        bytes32 migrationA,
+        bytes32 migrationB,
+        bytes32 anyHead
+    ) external {
+        vm.assume(writer != address(0));
+        assumeMigration(migrationA);
+        assumeMigration(migrationB);
+        vm.assume(migrationA != migrationB);
+
+        vm.warp(1000);
+        vm.prank(writer);
+        sRegistry.applyMigration(MIGRATION_HEAD_GENESIS, migrationA);
+
+        vm.warp(0);
+
+        vm.expectRevert(abi.encodeWithSelector(IMigrationRegistryV1.ZeroMigration.selector));
+        vm.prank(writer);
+        sRegistry.applyMigration(anyHead, bytes32(0));
+
+        vm.expectRevert(abi.encodeWithSelector(IMigrationRegistryV1.GenesisMigration.selector));
+        vm.prank(writer);
+        sRegistry.applyMigration(anyHead, MIGRATION_HEAD_GENESIS);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IMigrationRegistryV1.MigrationAlreadyApplied.selector, writer, migrationA)
+        );
+        vm.prank(writer);
+        sRegistry.applyMigration(MIGRATION_HEAD_GENESIS, migrationA);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMigrationRegistryV1.UnexpectedMigrationHead.selector, writer, MIGRATION_HEAD_GENESIS, migrationA
+            )
+        );
+        vm.prank(writer);
+        sRegistry.applyMigration(MIGRATION_HEAD_GENESIS, migrationB);
+
+        // With nothing left to say about the call, the block. This is what
+        // makes the four refusals above statements about the ORDER rather than
+        // about a check that was not live in this block at all.
+        vm.expectRevert(abi.encodeWithSelector(IMigrationRegistryV1.ZeroTimestamp.selector));
+        vm.prank(writer);
+        sRegistry.applyMigration(migrationA, migrationB);
+    }
+
     /// A record is confined to the caller's namespace. Applying under one
     /// writer says nothing about any other, which is what makes a reader's
     /// choice of namespace the whole of who it trusts — a hostile caller can
@@ -417,12 +470,32 @@ contract MigrationRegistryApplyMigrationTest is Test {
     /// The zero id is refused BEFORE the already-applied read and before the
     /// head, so it is always reported as `ZeroMigration` and never as anything
     /// about where the namespace is.
-    function testApplyMigrationZeroMigrationCheckedFirst(address writer, bytes32 anyHead) external {
+    ///
+    /// Fuzzed over the head against BOTH an empty namespace and one that has
+    /// moved on, for the same reason
+    /// `testApplyMigrationGenesisMigrationRevertsOnAnyHead` is: one namespace
+    /// state cannot tell the orderings apart, because a head the namespace
+    /// happens to be at is accepted whichever check runs first, and the two
+    /// states here have different heads so no fuzzed head matches both.
+    ///
+    /// The already-applied read can never answer anything but zero for this id
+    /// — this refusal is what keeps the zero id out of the records in the first
+    /// place — so what the second call pins is the reachable half of the same
+    /// claim: the refusal is a fact about the ID, not about the state of the
+    /// namespace it arrives at.
+    function testApplyMigrationZeroMigrationCheckedFirst(address writer, bytes32 anyHead, bytes32 migration) external {
         vm.assume(writer != address(0));
+        assumeMigration(migration);
 
         vm.expectRevert(abi.encodeWithSelector(IMigrationRegistryV1.ZeroMigration.selector));
         vm.prank(writer);
         sRegistry.applyMigration(anyHead, bytes32(0));
+
+        // A namespace that has moved on: the zero id is still reported as
+        // `ZeroMigration` rather than as anything about the head or about what
+        // has already been applied.
+        vm.prank(writer);
+        sRegistry.applyMigration(MIGRATION_HEAD_GENESIS, migration);
 
         vm.expectRevert(abi.encodeWithSelector(IMigrationRegistryV1.ZeroMigration.selector));
         vm.prank(writer);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/41.

`testApplyMigrationZeroMigrationCheckedFirst`'s two blocks were byte identical,
so the test read as making two assertions while constructing one state twice.
The second block now applies a migration first, so the zero id arrives at a
namespace that has moved on rather than at a second empty one.

The issue also asked for the mutant that belongs with it, and for the sibling
ordering tests to be swept for the same shape. Both are here, and the sweep
found a real gap that is not the one the issue predicted.

## The fix

`test/src/concrete/MigrationRegistryApplyMigration.t.sol`:

- `testApplyMigrationZeroMigrationCheckedFirst` takes a third fuzzed
  `migration`, applies it between the two zero-id calls, and so puts the second
  call against a head that is not genesis. The two states have different heads,
  so no fuzzed `anyHead` can match both, which is what makes the head half of
  the ordering claim pinned for EVERY head rather than for every head the
  fuzzer happens to reach.
- `testApplyMigrationZeroTimestampCheckedLast` is new: the sweep's find, below.

No source change. `MigrationRegistry` behaves exactly as it did; what moved is
what the suite can tell apart.

## The mutant the issue named is EQUIVALENT, and that is a measured result

The issue asked for "the zero-id refusal moved after the already-applied check"
and for confirmation that the strengthened test kills it. It is N01 in the table
below, and it SURVIVES — before the fix and after it. Not because the test is
still weak: because no test can kill it.

- `sApplied` is written in exactly one place, the
  `sApplied[msg.sender][migration] = block.timestamp;` at the end of
  `applyMigration`.
- Under the mutant the zero-id refusal still sits before that write — it moves
  to between the already-applied read and the head check — so no execution
  reaches the write with `migration == bytes32(0)`.
- So `sApplied[writer][bytes32(0)]` is zero for every writer in every reachable
  state, under the original AND under the mutant. The already-applied branch is
  never taken for the zero id in either, and the two programs return the same
  revert data, leave the same storage and emit the same logs for every call
  sequence there is.

The issue's stated consequence — "a re-dispatched script passing a zero id
would be answered `MigrationAlreadyApplied` rather than `ZeroMigration`" — is
therefore not reachable. The only state that separates the two programs is
`sApplied[writer][0] != 0`, which is exactly the state this refusal exists to
make impossible, so a test could only construct it with `vm.store` and would be
asserting about a state the contract cannot be in. That is not written, and the
docstring is not weakened: the ordering it describes is real, one half of it
just has no behaviour to observe. The docstring now says which half is which,
so the same gap is not re-filed against the same lines.

G01 is the identical situation in the genesis sibling, probed for the symmetry
and equivalent for the identical reason.

## What the second block DOES pin

That the zero-id refusal is a fact about the ID rather than about the state of
the namespace it arrives at — N02 in the table, the refusal made conditional on
an empty namespace. That mutant dies on `main` too, but only to
`testApplyMigrationNoEventOnRevert`, a test about logs that happens to call with
a zero id on a used namespace. The coverage for the claim now lives in the test
that makes the claim, instead of depending on an unrelated test's incidental
state.

## The sweep, and the ordering nothing probed

`applyMigration`'s documented order is

    zero id -> genesis id -> already applied -> head -> zero timestamp -> write

and the three siblings the issue named check out:

- `testApplyMigrationGenesisMigrationRevertsOnAnyHead` — asserts the head half
  only, and constructs both namespace states for it. M25, G02 killed.
- `testAppliedZeroWriterCheckedFirst` — asserts the writer is checked before
  the migration, and its two blocks are the two ways that can be wrong. A01,
  A02 (each migration refusal moved ahead of the writer one, separately) killed
  by it.
- `testApplyMigrationAlreadyAppliedCheckedBeforeHead` — names a head the
  namespace provably is not at, so the ordering is discriminated for every
  fuzzed input. M22 killed.

The gap is one step further down the chain, in the pair the issue's own quoted
order ends on. `MigrationRegistry.applyMigration` documents "the refusals run
caller-input first and environment last", and nothing tested it: every call in a
zero-timestamp block was a call whose arguments were correct, so the
zero-timestamp check could be moved ahead of ALL FOUR input refusals and no test
noticed (T01, T02, both SURVIVED on `main`).

That matters for the same reason the issue's does: it changes what a caller is
told. A script with a bad predecessor, dispatched into such a block, would be
told to come back later instead of being told its head is wrong.

`testApplyMigrationZeroTimestampCheckedLast` warps to zero on a namespace that
has already applied something and drives all four input refusals through it —
zero id, genesis id, already applied, wrong head — then closes with a call whose
arguments are all correct and gets `ZeroTimestamp`. The last one is what stops
the other four being vacuous: it proves the environment check was live in that
block.

## Mutation pass

Harness: `mutation-probe` from `rainlanguage/adversarial-mutation-test`
(`d195fd8`), declarative `(file, target, replacement)` triples. A target that
does not match exactly once is HARNESS-ERROR, not a survivor; a suite with no
proof it ran is NO-RUN, not a kill.

Scoped to `test/src/concrete/MigrationRegistry*.t.sol` for the reason #39's pass
was: the contract's creation code is pinned and anchored to source, so at whole
suite scope `testSnapshotMatchesSource` kills every mutation of it whatever the
behavioural tests do. Here a KILL is a behavioural test and nothing else.

Baseline green at 44 before, 45 after. **11 mutants, 9 killed, 2 survived — both
proven equivalent — 0 no-run, 0 harness errors.**

| Mutant | On `main` | After | Killed by |
| --- | --- | --- | --- |
| N01 zero-id refusal moves AFTER the already-applied check | SURVIVED | SURVIVED | EQUIVALENT — no reachable state distinguishes it |
| N02 the zero-id refusal applies only while the namespace is empty | KILLED | KILLED | `testApplyMigrationZeroMigrationCheckedFirst` (was: `testApplyMigrationNoEventOnRevert` only) |
| G01 genesis refusal moves AFTER the already-applied check | SURVIVED | SURVIVED | EQUIVALENT — same reason as N01 |
| G02 the genesis refusal applies only while the namespace is empty | KILLED | KILLED | `testApplyMigrationGenesisMigrationRevertsOnAnyHead` |
| T01 the zero-timestamp refusal moves to the TOP | SURVIVED | KILLED | `testApplyMigrationZeroTimestampCheckedLast` |
| T02 the zero-timestamp refusal moves BEFORE the head check | SURVIVED | KILLED | `testApplyMigrationZeroTimestampCheckedLast` |
| A01 `applied`'s zero-writer refusal moves AFTER the zero-migration refusal | KILLED | KILLED | `testAppliedZeroWriterCheckedFirst` |
| A02 `applied`'s zero-writer refusal moves AFTER the genesis-migration refusal | KILLED | KILLED | `testAppliedZeroWriterCheckedFirst` |
| M22 the already-applied refusal moves AFTER the head check | KILLED | KILLED | `testApplyMigrationAlreadyAppliedCheckedBeforeHead` |
| M24 zero-id refusal moves AFTER the head check | KILLED | KILLED | `testApplyMigrationZeroMigrationCheckedFirst` |
| M25 genesis refusal moves AFTER the head check | KILLED | KILLED | `testApplyMigrationGenesisMigrationRevertsOnAnyHead` |

The two remaining adjacent pairs in the documented chain are recorded rather
than left blank: zero id vs genesis id has no input that reaches the second
check with the first true, and zero id / genesis id vs already applied is N01 /
G01, equivalent.

The table was re-run from scratch at `386bb73` against the same mutant file and
reproduced verdict for verdict — baseline green at 45, 9 killed, N01 and G01
survived, 0 no-run, 0 harness errors — so the two SURVIVED rows are a measured
result of a suite that provably ran, not a harness that failed to apply them.

It stands unchanged at this branch's current head. Merging `main` in changed no
file under `src/` and no file the pass was scoped to
(`test/src/concrete/MigrationRegistry*.t.sol`), so both the mutated source and
the filtered test set are byte-identical to what produced the table.

Mutant file and machine reports at
`/home/gildlab/artifacts/rain-deploy-41-mutants.toml` and
`rain-deploy-41-mutation-report{-premain,,-verify}.json`.

## Gates

All run at `6d8488f`, this branch's head, which is `386bb73` with `main` merged
in at `c9f3ed6`. Local gates in the repo's own `nix develop` shell.

| Gate | Outcome |
| --- | --- |
| `forge test` (local, whole repo) | pass — 17 suites, **215 passed, 0 failed, 0 skipped**. |
| `rainix / test / test` (CI) | pass — the same 215 passed, 0 failed, 0 skipped. |
| `rainix / legal / legal` (CI) | pass |
| `rainix / static / static` (CI) | pass |
| `slither .` | pass — 49 contracts analysed with 100 detectors, **0 results** |
| `reuse lint` | pass — 69/69 files carry both copyright and licence, compliant with REUSE 3.3, 0 bad/deprecated/missing/unused |
| `pre-commit run --all-files` | pass — deadnix, denofmt, nil, nixfmt, no-consumer-prettier, prettier-rainix, statix, taplo, yamlfmt all Passed; rustfmt and shellcheck had no files. **No file modified**, so nothing was reformatted under it. |
| `forge script script/Build.sol` | pass, and **idempotent** — the script ran successfully and `git status` was empty afterwards, so the committed `src/generated/candidate/` records and the `Lib*Deploy` aliases are exactly what this tree regenerates. |
| CodeRabbit | **PENDING — the green tick is vacuous.** The check reports `pass` with the description `Review rate limited`: it hit the per-developer review limit and never started, so it has still never read this diff, and there are zero review threads on this PR. Re-requested with `@coderabbitai review`; this row is not passed until a real review lands and has been read. |

### What merging `main` brought in, and the red it cleared

This branch was cut from `548604c` and `main` has since moved to `c9f3ed6`, so
`main` is merged in here rather than rebased onto. Nine files, none of them this
PR's: `31f19e7` removes the submodule-era residue (`foundry.lock`, the
`.gitmodules` and `lib/` entries in `.soldeerignore` and `REUSE.toml`), and
`dd098d5` / `db6d7c1` from
https://github.com/rainlanguage/rain.deploy/pull/42 rewrite the chain-verify
tests. The diff this PR proposes is still exactly
`test/src/concrete/MigrationRegistryApplyMigration.t.sol` and nothing else.

That merge is what cleared the one red this branch used to carry.
`testChainNotDeployedReverts` picked an address it expected to hold no code and
asserted `NotDeployedOnNetwork`; the `AddressRegistry` candidate went live on
all five supported networks, so the address it picked acquired code and the call
it expected to revert stopped reverting. A fact about the chains, not about this
diff — `test/src/abstract/RainDeployVerifyChain.t.sol` and everything it read
were byte-identical to `main` throughout, and the test went red on a `main`
nobody had touched. #42 fixes it by constructing the absence instead of assuming
it. Merged in, the whole suite is green here, locally and on CI, with no change
to this branch's own diff — which is why it was never duplicated onto this
branch.

## QA

- **Discriminating tests:** `testApplyMigrationZeroMigrationCheckedFirst`
  strengthened in place, `testApplyMigrationZeroTimestampCheckedLast` new.
  Discrimination is verified by mutation, per the table.
- **Mutations applied:** the eleven above, probed against `main` and against
  this branch. Two survivors, both proven equivalent rather than left as gaps.
- **Oracle:** the docstrings' own ordering claims and
  `MigrationRegistry.applyMigration`'s "caller-input first and environment
  last", treated as the spec and checked against what the calls construct.
- **Category check:** the issue asks for (a) the strengthened test, (b) the
  mutant that belongs with it, (c) a sweep of the three named siblings for
  claims wider than their calls, with a mutant per ordering. All three covered;
  (b) came back equivalent, with the proof above rather than a manufactured
  kill.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded migration validation coverage for zero timestamps across invalid, genesis, already-applied, and unexpected-head scenarios.
  * Added checks for zero-migration behavior in both empty and advanced namespaces.
  * Verified migration ordering after applying a valid migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->