### PR TITLE
docs(address-registry): state that the compiled root is zero and the registry inert

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ root authority binds a name, anyone reads a bound name, and reading an unbound
 name reverts rather than answering with the zero address. There is no removal,
 no upgrade and no authority besides root.
 
+**Root is `address(0)` during rollout, so a registry deployed now is inert.**
+`ADDRESS_REGISTRY_ROOT` in `src/concrete/AddressRegistry.sol` is the one place
+that value lives. Nothing calls from the zero address, so no name can be bound,
+and every read of an unbound name reverts — it fails loudly in both directions
+and can never answer with a wrong address. Root is welded into the creation
+code, so setting a real one moves the deploy address, the code hash and the
+snapshot with it: the registry compiled under a zero root is not the one a
+consumer will eventually resolve against, and deploying it now is not
+preparation for the one that is.
+
 Bindings are **mutable**, because the addresses they name are. Rotating an
 owning multisig is ordinary business and has to be expressible without moving
 anybody's deterministic address — which a binding welded to one address forever


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/79 (audit `PROC-04`, filed MEDIUM, downgraded to LOW by its own verification pass).

## The defect

README's `## Address registry` section described binding, reading and rotation entirely in the present tense — "An immutable root authority binds a name, anyone reads a bound name" — and never said that the compiled root is zero. `src/concrete/AddressRegistry.sol:22` is `address constant ADDRESS_REGISTRY_ROOT = address(0);`, and both the constant's own NatSpec and `CLAUDE.md:118-123` spell out the consequence. README was the one document of the three that did not, while also offering the registry (lines 18-20) as the answer to "How does a deployment get a configured address".

Verified by reading the contract, not assumed from the issue:

- `register` reverts `NotRoot(msg.sender)` unless `msg.sender == ADDRESS_REGISTRY_ROOT`. No call can originate from the zero address, so while root is zero **no name can be bound by anybody**.
- `get` reverts `NameNotRegistered(name)` whenever the mapping reads zero — which is every name, since nothing can be bound. It either reverts or returns a bound non-zero address, so there is no path to a silently wrong answer.
- Root is a compile-time constant, hence part of the creation code, so setting a real one moves the deterministic address, the code hash and the generated snapshot together.

## The change

Ten lines of README, inserted where the issue asked for them: immediately after the section's opening paragraph, so a reader learns the section's subject and then its current state before reading three paragraphs of live-sounding rotation semantics.

```
**Root is `address(0)` during rollout, so a registry deployed now is inert.**
`ADDRESS_REGISTRY_ROOT` in `src/concrete/AddressRegistry.sol` is the one place
that value lives. Nothing calls from the zero address, so no name can be bound,
and every read of an unbound name reverts — it fails loudly in both directions
and can never answer with a wrong address. Root is welded into the creation
code, so setting a real one moves the deploy address, the code hash and the
snapshot with it: the registry compiled under a zero root is not the one a
consumer will eventually resolve against, and deploying it now is not
preparation for the one that is.
```

## Two departures from the issue's proposed text, both taken from its own verification block

The verification noted the proposed fix "could be a single sentence pointing at the constant rather than a duplicated paragraph that will rot when root is set". Taken, but not all the way to one sentence:

1. **Pointer, not duplicate.** The text names `ADDRESS_REGISTRY_ROOT` and its file as the one place the value lives, instead of re-deriving the creation-code/address/code-hash/snapshot cascade that the constant's NatSpec already carries at length. Setting a real root now rots one clause here, not a third full copy of the rationale.
2. **Kept the "not preparation" consequence.** This is the one claim that could not shrink to a pointer. Without it a reader can conclude that dispatching the `address-registry` suite today is harmless groundwork; the whole point is that setting root moves the address, so the deployed artifact is not the one consumers will ever resolve against. That is the sentence standing between README and a wasted multi-network dispatch.

Not touched, deliberately: the opening question list (lines 18-20) and the matching approach bullet describe what the library is *for*, which is true independent of rollout state. Caveating those too would scatter one fact across three places in one file; the section that describes the mechanism is where its state belongs.

The MigrationRegistry section already said, as a contrast, that it has "no rollout state in which it is inert" the way a welded root like `ADDRESS_REGISTRY_ROOT` produces. That forward reference now has an antecedent.

## QA

- Discriminating tests: n/a — the diff is ten lines of README and touches no Solidity, no script and no generated snapshot, so there is no executable behaviour for a test to discriminate on. What replaces a test here is reading the contract the prose makes claims about: each claim in the new paragraph is checked against `src/concrete/AddressRegistry.sol` in "The defect" above (`register`'s `NotRoot` guard against a constant that is `address(0)`, `get`'s `NameNotRegistered` guard, root's residence in the creation code).
- Mutations applied: n/a — a docs-only diff has no lines whose mutation any test could kill. The equivalent adversarial check was to try to falsify the paragraph against source: the strongest claim in it is "can never answer with a wrong address", and `get`'s only two exits (revert, or a non-zero mapping value written by `register`, which itself rejects `address(0)`) leave no third one.
- Oracle: `src/concrete/AddressRegistry.sol` — the contract's actual revert conditions and the constant at line 22, read directly. Deliberately NOT the issue's prose, the existing NatSpec or `CLAUDE.md`, all of which are the documents under review; a README agreeing with them would be worth nothing if they were the thing that was wrong.
- Category check: the issue asks for exactly one thing — README must state that `ADDRESS_REGISTRY_ROOT` is `address(0)` and what follows for a registry compiled under it. Covered, at the anchor the issue named (after line 153). The issue's problem statement also cites lines 18-20 as contributing; covered by judgement rather than by edit, with the reason stated above — those lines describe the library's purpose, which the rollout state does not make false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
