### PR TITLE
Deploy dispatch stops restating the suite registry, and can name a released suite

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -9,24 +9,48 @@ name: Manual sol artifacts
 # Order is: dispatch this once per suite, confirm `RegistryDeployChainTest`
 # passes on every supported network, then push the `sol-v*` tag.
 #
+# That is the pre-release use. The other one is after a release: adding a
+# network reds `RegistryDeployChainTest` until every RELEASED suite is live on
+# it, and the fix is to dispatch that release's own key — `<key>@<tag>`, the
+# frozen creation code — not the candidate, which is different bytes at a
+# different address. Both uses are the same dispatch with a different key.
+#
 # Deliberately `workflow_dispatch` only. Broadcasting is key custody and real
 # money; nothing about a merge or a tag should trigger it.
 on:
   workflow_dispatch:
     inputs:
       suite:
-        type: choice
+        type: string
         required: true
         description: |
-          Which declared suite to broadcast. One dispatch deploys one suite,
-          because `DEPLOYMENT_SUITE` selects one — a repo with two deployed
-          contracts is two dispatches. Offered as a choice rather than typed,
-          so a key that no suite declares cannot be dispatched at all; the
-          script still refuses one, naming the valid keys, if this list falls
-          behind the declaration.
-        options:
-          - address-registry
-          - migration-registry
+          Which declared suite to broadcast, spelled exactly as the declaration
+          spells it. One dispatch deploys one suite, because `DEPLOYMENT_SUITE`
+          selects one — a repo with two deployed contracts is two dispatches.
+
+          Typed rather than chosen from a list, so this file is not a second
+          copy of the declaration. The keys are `allSuites()` — the candidates
+          `RegistryDeploySuites` names, plus one per frozen release, and the
+          released ones are GENERATED as `<key>@<tag>` (`address-registry@0_1_6`)
+          by `cutRelease()`. A hand-written `options:` list could hold only the
+          candidates, which would make every release undispatchable — and
+          broadcasting a release on its own is exactly what a network added
+          after that release needs. There is one list, in Solidity:
+          `suiteByName` refuses an undeclared key with `UnknownDeploymentSuite`,
+          naming every valid one, before `DEPLOYMENT_KEY` is read and before
+          anything forks, so a typo costs seconds and no gas.
+      verify:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to pass `--verify` to `forge script`. Leave ON for a candidate
+          key, which is a snapshot of current source.
+
+          Turn it OFF for a RELEASED key (`<key>@<tag>`): that broadcasts the
+          creation code the release froze, which is not what current source
+          compiles to once source has moved, so explorer verification against
+          source fails the run AFTER the gas is spent.
 jobs:
   deploy:
     uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
@@ -34,4 +58,8 @@ jobs:
       # Passed through as DEPLOYMENT_SUITE; script/Deploy.sol dispatches on it
       # and reverts on anything else.
       suite: ${{ inputs.suite }}
+      # The reusable defaults this to true, so it has to be passed to be
+      # turnable off — a released suite broadcasts frozen bytes that current
+      # source no longer matches.
+      verify: ${{ inputs.verify }}
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,9 +399,13 @@ expected addresses, expected code hashes, and dependency lists.
 - **Deploy, then verify, then tag** — in that order, and they are three separate
   things. `script/Deploy.sol` broadcasts the suite `DEPLOYMENT_SUITE` names to
   every network in `supportedNetworks()`, dispatched by hand through
-  `.github/workflows/manual-sol-artifacts.yaml`, whose `suite` input is a choice
-  over the declared keys. One suite per dispatch, so this repo's two registries
-  are two dispatches. Only then is there a deployment for `rainix-tag-release`
+  `.github/workflows/manual-sol-artifacts.yaml`, whose `suite` input is typed
+  rather than picked from a list — the workflow is not a second copy of the
+  declaration, so it cannot fall behind it, and released keys are generated as
+  `<key>@<tag>` and could never appear in a hand-written list at all. An
+  undeclared key is refused by `suiteByName` naming the valid ones, before the
+  key is read. One suite per dispatch, so this repo's two registries are two
+  dispatches. Only then is there a deployment for `rainix-tag-release`
   to verify pins against — it verifies and publishes, it never broadcasts.
   Broadcasting is key custody and real money, so it is `workflow_dispatch` and
   nothing else. Deploying is idempotent: a network that already has the code is

--- a/README.md
+++ b/README.md
@@ -288,12 +288,23 @@ Three separate steps, in this order. Nothing automatic ever broadcasts.
 
 1. **Deploy.** Dispatch the
    [`Manual sol artifacts`](.github/workflows/manual-sol-artifacts.yaml)
-   workflow, choosing a `suite`. It runs `script/Deploy.sol` and broadcasts that
+   workflow, typing a `suite`. It runs `script/Deploy.sol` and broadcasts that
    suite to every network in `supportedNetworks()`. One suite per dispatch, so
    this repo's two registries are two dispatches. `workflow_dispatch` only: this
    is key custody and real money, and no merge or tag should be able to trigger
    it. It is idempotent — a network that already has the code is skipped — so a
    partial run is fixed by running it again rather than by unpicking anything.
+
+   The key is any key the declaration declares — a candidate
+   (`address-registry`) or a frozen release (`address-registry@0_1_6`). A typed
+   input rather than a dropdown, because a dropdown would be a second copy of
+   the declaration and could never name a release, whose key is generated when
+   the release is cut. An undeclared key is refused in seconds, naming the valid
+   ones, before the deploy key is read.
+
+   Turn `verify` OFF when the key names a release: it broadcasts the creation
+   code that release froze, which current source no longer compiles to, so
+   verifying against source would fail the run after the gas is spent.
 2. **Verify.** `RegistryDeployChainTest` passes only once every **released**
    suite is live on every supported network, with the code that release froze.
    This repo has released none, so today it has nothing to check and passes; it


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/44

## What was wrong

`.github/workflows/manual-sol-artifacts.yaml` declared `suite` as `type: choice` with `address-registry` and `migration-registry` hardcoded — a second enumeration of the key set `RainDeploySuitesBase.allSuites()` declares.

That copy is structurally incapable of holding half the key set. Released keys are GENERATED: `LibRainDeploySnapshot` emits `suite: "<template.suite>@<tag>"` when `cutRelease()` freezes a release, so `address-registry@0_1_6` can never appear in a list hand-written before any tag exists. `type: choice` rejects an unlisted value, so **no released suite was dispatchable through the only sanctioned deploy path, today or ever** — and the script's fail-closed `UnknownDeploymentSuite(requested, suiteNames())` was never reached to say so, because GitHub refuses the dispatch before the job starts.

The blocked operation is the one `DeploySuite`'s own NatSpec names (`src/abstract/RainDeploySuitesBase.sol:54-57`): a chain added after a release is exactly when an OLD snapshot has to be broadcast on its own. `RegistryDeployChainTest` reds on that state and stays red. The reachable-but-wrong answer was to dispatch the candidate key, which broadcasts different bytes to a different deterministic address and leaves the red where it was.

Second half of the same defect: the caller passed only `suite`, and `rainix-manual-sol-artifacts` defaults `verify: true`, documented verbatim as something to disable when "deploying bytecode that does not match the current source (e.g. a pinned historical release deployed from stored creation code)". So even with the key available, a released-suite dispatch would broadcast and then fail explorer verification **after** the gas was spent.

## The fix

- `suite` is now `type: string`. There is one list, in Solidity. `suiteByName` refuses an undeclared key naming every valid one, before `DEPLOYMENT_KEY` is read and before anything forks — a typo costs seconds and no gas, which is the fail-closed behaviour the dropdown was standing in for and could not deliver.
- `verify` is a new dispatch input, `boolean`, `default: true` (current behaviour), passed through to the reusable. Turned off, it is how a frozen release gets broadcast without failing verification against source that has since moved.
- The file's header now names the post-release use — adding a network means dispatching `<key>@<tag>`, not the candidate — so the workflow does not read as pre-release-only.
- `CLAUDE.md` said the input was "a choice over the declared keys" and `README.md` said "choosing a `suite`". Neither was true even for candidates. Both now describe what the input is, and README step 1 says when to turn `verify` off.

Side effect worth noting: `src/abstract/RegistryDeploySuites.sol:79-81` claims a third deployed contract is "a third named candidate below, a third entry here, and a third entry in `script/Build.sol`'s generated-contract list — nothing else". That was false while the dropdown existed (it needed a fourth edit, here). It is true again now, so that docstring needed no change.

## No test, deliberately

Two of the five collected findings proposed keeping the dropdown and binding it with a test that parses the YAML (granting `fs_permissions` read on `./.github`). Those tests presuppose the second copy: with `options:` gone there is no key set in this file, so there is nothing that can fall behind the declaration and nothing for a test to compare. The only assertion left available would be that a construct is absent — grep-shaped, permanently widening the test tree's filesystem access, guarding against a decision this file now explains at length. Say so if you want it anyway.

## QA

- Discriminating tests: n/a — the diff is a `workflow_dispatch` input declaration plus prose; nothing in it is reachable from `forge test`, and the repo grants no `fs_permissions` on `./.github` (`grep -rn "\.github" src/ test/ script/` is zero, unchanged by this PR). The executed check is `actionlint` over all three workflows, exit 0, which parses the YAML and validates the reusable call's schema. The only fuller check is dispatching the workflow, which is key custody and real money.
- Mutations applied: n/a — no executable code in the diff to mutate, and no test over it to survive a mutant. The equivalent adversarial pass was done by hand against the upstream contract: `verify: ${{ inputs.verify }}` was checked to name a real input of the reusable at `@main` (not invented), and typed `boolean` on both sides so the passthrough is type-clean rather than a string that fails template validation at dispatch time.
- Oracle: read independently of the file being changed. `rainlanguage/rainix@main`'s `rainix-manual-sol-artifacts.yaml` for the reusable's own input declarations (`suite: type: string`, `verify: type: boolean, default: true`, and its `${{ inputs.verify && '--verify' || '' }}` use); `src/lib/LibRainDeploySnapshot.sol:612-616` for released keys being emitted as `<suite>@<tag>`; `src/abstract/RainDeploySuitesBase.sol` `allSuites`/`suiteNames`/`suiteByName` for what the valid key set actually is; `src/abstract/RainDeployBroadcast.sol:run()` for `suiteByName` preceding `vm.envUint("DEPLOYMENT_KEY")`, which is what makes the typo-costs-no-gas claim true.
- Category check: the issue collects five findings on one defect with two halves. Both covered — the second enumeration is removed (`choice` -> `string`, three of the five findings' structural fix) and the missing `verify` passthrough is added (the MEDIUM finding's second half). The category, not just the examples: every doc surface asserting the now-false property was swept, not only the one line the findings quoted — `CLAUDE.md` and `README.md` both fixed, `script/Deploy.sol` and `src/abstract/RegistryDeploySuites.sol` checked and correct as they stand. The two findings that instead proposed keeping the dropdown plus a YAML-parsing test are answered above, not silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
