### PR TITLE
ci: daily scheduled sol sweep so chain drift is caught without a push

### DIFF
--- a/.github/workflows/rainix-sol-scheduled.yaml
+++ b/.github/workflows/rainix-sol-scheduled.yaml
@@ -1,0 +1,52 @@
+name: rainix-sol-scheduled
+# The same sol suite as `rainix.yaml`, on a clock instead of on a push.
+#
+# `RegistryDeployChainTest` asks whether every RELEASED registry is live, with
+# the code its release froze, on every network in `supportedNetworks()`. That is
+# the one check whose answer changes without this repo changing: a pin can go
+# from true to false because a chain reorged past the deploy, because a release
+# was declared for a deployment that never landed on one of the five networks,
+# or because the code at the address is not the code the snapshot recorded.
+# Push-triggered CI cannot see any of it — a deploy repo deliberately does not
+# move between releases, so the push that would have asked can be months away,
+# and the pins consumers are already using are wrong for all of that time.
+#
+# Scheduled runs use the default branch, which for this repo is precisely the
+# branch that carries the current release's pins (`rainix-tag-release` commits
+# the frozen snapshot and the released-suites declaration back to main), so the
+# constants under test here are the ones consumers resolve.
+#
+# Separate workflow rather than a `schedule:` added to `rainix.yaml`, matching
+# the org's other deploy repos: the two triggers answer different questions and
+# a red run should say on sight which one asked. `workflow_dispatch` is here so
+# the sweep can be run on demand — after a manual deploy, or to re-check a chain
+# that was unreachable — without waiting for the next cron tick.
+#
+# The schedule lives in this repo and not in a rainix reusable because it cannot
+# live anywhere else: `rainix-sol.yaml` is `on: workflow_call`, and GitHub only
+# honours `schedule:` in the workflow that the event triggers. A reusable cannot
+# schedule itself, so the trigger is necessarily consumer-side even though the
+# jobs it runs are the shared rainix ones.
+#
+# Known gap, not fixed here: GitHub disables scheduled workflows in a PUBLIC
+# repository after 60 days with no repository activity, and a release-frozen
+# deploy repo is exactly the repo that goes quiet that long. When that happens
+# the sweep stops silently and has to be re-enabled by hand, so a repo that has
+# been idle past 60 days is not covered by this and `workflow_dispatch` is the
+# only way to ask.
+on:
+  schedule:
+    # Daily, 03:17 UTC. Off the hour deliberately: GitHub's scheduler drops or
+    # delays on-the-hour crons under load, and the deploy repos stagger their
+    # sweeps so they do not all queue against the same fork RPC endpoints.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+jobs:
+  rainix-sol:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main
+    # `inherit`, like every other workflow in this repo. The alternative — an
+    # explicit per-secret list — is a second copy of rainix's declared secret
+    # set that nothing keeps in sync: a network added to `[rpc_endpoints]` and
+    # to rainix would fork on push and silently not fork here, which is the same
+    # class of invisible gap this workflow exists to close.
+    secrets: inherit

--- a/.github/workflows/rainix-sol-scheduled.yaml
+++ b/.github/workflows/rainix-sol-scheduled.yaml
@@ -16,11 +16,11 @@ name: rainix-sol-scheduled
 # the frozen snapshot and the released-suites declaration back to main), so the
 # constants under test here are the ones consumers resolve.
 #
-# Separate workflow rather than a `schedule:` added to `rainix.yaml`, matching
-# the org's other deploy repos: the two triggers answer different questions and
-# a red run should say on sight which one asked. `workflow_dispatch` is here so
-# the sweep can be run on demand — after a manual deploy, or to re-check a chain
-# that was unreachable — without waiting for the next cron tick.
+# Separate workflow rather than a `schedule:` added to `rainix.yaml`: the two
+# triggers answer different questions and a red run should say on sight which
+# one asked. `workflow_dispatch` is here so the sweep can be run on demand —
+# after a manual deploy, or to re-check a chain that was unreachable — without
+# waiting for the next cron tick.
 #
 # The schedule lives in this repo and not in a rainix reusable because it cannot
 # live anywhere else: `rainix-sol.yaml` is `on: workflow_call`, and GitHub only
@@ -36,9 +36,8 @@ name: rainix-sol-scheduled
 # only way to ask.
 on:
   schedule:
-    # Daily, 03:17 UTC. Off the hour deliberately: GitHub's scheduler drops or
-    # delays on-the-hour crons under load, and the deploy repos stagger their
-    # sweeps so they do not all queue against the same fork RPC endpoints.
+    # Daily, 03:17 UTC. Off the hour deliberately: GitHub's scheduler delays or
+    # drops on-the-hour crons under load, since that is when everything queues.
     - cron: "17 3 * * *"
   workflow_dispatch:
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,16 @@ the block above is what they run.
 A fourth workflow, `Manual sol artifacts`, is `workflow_dispatch` only and is
 the on-chain deploy — nothing automatic ever broadcasts.
 
+Those same three tasks run twice over: on every push (`rainix.yaml`) and daily
+on a schedule (`rainix-sol-scheduled.yaml`, also `workflow_dispatch`). The
+schedule exists for group 4 below — `RegistryDeployChainTest` is red on chain
+state that changes with nobody touching this repo, and between releases this
+repo is not touched for months, so a push is not an event that can be waited
+for. Scheduled runs use the default branch, which carries the current release's
+pins. GitHub disables scheduled workflows in a public repo after 60 days of no
+repository activity, which a release-frozen deploy repo can reach; past that the
+sweep has to be re-enabled by hand.
+
 ## RPC Configuration
 
 Fork tests require RPC endpoints defined in `.env` (gitignored):
@@ -340,7 +350,8 @@ Four groups, sorted by what they are anchored to:
    `supportedNetworks()`, every RELEASED version's derived address carries code
    with its derived code hash. The only check that catches "never deployed" or
    "not there any more", neither of which the repo can hold: both go false with
-   nobody touching it.
+   nobody touching it — which is why it is also run on a daily schedule
+   (`rainix-sol-scheduled.yaml`) and not only on push.
 
 Group 4 is released-only for the mirror image of group 2's reason. A release IS
 a deployment that happened; a candidate is what the next release will be, and

--- a/README.md
+++ b/README.md
@@ -298,7 +298,12 @@ Three separate steps, in this order. Nothing automatic ever broadcasts.
    suite is live on every supported network, with the code that release froze.
    This repo has released none, so today it has nothing to check and passes; it
    gets a subject the moment step 3 freezes one, and is red from then until step
-   1 has been run everywhere. That is the order these steps are in.
+   1 has been run everywhere. That is the order these steps are in. It is not
+   asked once:
+   [`rainix-sol-scheduled`](.github/workflows/rainix-sol-scheduled.yaml) re-runs
+   the sol suite daily against `main`, because a released pin stops being true —
+   a chain rolls back, a network never got the deploy — without anything in this
+   repo changing to trigger a push build.
 3. **Tag.** Push a `sol-v*` tag. `rainix-tag-release` regenerates the snapshot
    for the version the tag names, verifies the live chains against those fresh
    pins, publishes to Soldeer and commits the frozen snapshot back to `main`. It


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/77

## What was wrong

`.github/workflows/rainix.yaml` is `on: [push]` and was the only workflow that
runs `forge test` — `package-release.yaml` is tag-only, `manual-sol-artifacts.yaml`
is `workflow_dispatch` only. `RegistryDeployChainTest` is the one check whose
answer changes with nobody touching this repo: a released pin stops being true
when a chain rolls back past the deploy, when a network never received it, or
when the code at the address is not the code the snapshot froze. Wiring the only
detector for repo-independent state to a repo-dependent event means that between
releases — which for a deploy repo is months by design — nothing asks, while
consumers are pinning the address.

## The fix

New `.github/workflows/rainix-sol-scheduled.yaml`: the same
`rainix-sol.yaml@main` reusable, on `schedule: 17 3 * * *` plus
`workflow_dispatch`. Scheduled runs execute on the default branch, which is the
branch `rainix-tag-release` commits the current release's frozen pins back to,
so the constants under test are the ones consumers resolve. `CLAUDE.md` and
`README.md` are updated so the CI description and the deploy/verify/tag
lifecycle describe what now exists.

## This is the first scheduled workflow in the org, and does not follow a precedent

An earlier revision of this PR and of the workflow comment claimed this shape
matched "the org's other deploy repos". **That was false and has been removed**
in 2bf45f9. Enumerated against default branches just now:

| repo | workflows | any cron? |
| --- | --- | --- |
| `rainlanguage/rain.deploy` | `rainix.yaml` (`on: [push]`), `package-release.yaml` (tag), `manual-sol-artifacts.yaml` (dispatch) | none |
| `rainlanguage/rain.factory.deploy` | `rainix-sol.yaml` (`on: [push]`), `package-release.yaml`, `manual-sol-artifacts.yaml` | none |
| `rainlanguage/dvin.deploy` | `rainix.yaml` (`on: [push]`), `manual-sol-artifacts.yaml`, `git-clean.yaml` | none |

Zero cron lines across all nine workflow files. **This PR is the first scheduled
workflow in any rainlanguage deploy repo**, and it should be reviewed as a new
decision rather than as conformance to something.

The prior art I actually worked from is `S01-Issuer/st0x.deploy` —
[`rainix-sol-scheduled.yaml`](https://github.com/S01-Issuer/st0x.deploy/blob/main/.github/workflows/rainix-sol-scheduled.yaml)
on its default branch, `cron: "17 6 * * *"` + `workflow_dispatch`, calling this
same rainix reusable. That is a **different org**, so it is evidence the shape
works against these reusables, not evidence of a rainlanguage convention. I am
citing it as the former only.

## Does this belong in rainix?

No, and it is worth stating explicitly because the org convention is that shared
CI lives in rainix reusables rather than in consumer repos. The **jobs** already
do live there and this PR adds none — it calls
`rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main` unchanged. Only the
**trigger** is added here, and it cannot go anywhere else: `rainix-sol.yaml` on
rainix's default branch is `on: workflow_call`, and GitHub honours `schedule:`
only in the workflow the event triggers, so a reusable cannot schedule itself. A
`rainix-sol-scheduled` reusable in rainix would still need a consumer-side caller
carrying the cron, i.e. this same file with an extra hop.

rainix already assumes this sweep exists without providing it:
`rainix-tag-release.yaml` on rainix main says "commits the new (append-only)
snapshot back to main so the daily drift sweep always has the current release's
pins to check" (lines 32-33) and "main carries the CURRENT release's pins so the
daily drift sweep has live constants to check" (line 268). Given the table
above, no rainlanguage repo was providing the sweep those comments assume.

## Two deliberate departures, both worth checking

1. **Separate workflow, not a `schedule:` added to `rainix.yaml`** — the issue's
   proposed patch bolts the trigger onto the push workflow; the issue's own
   verification block flags that shape as off. The reason to take the separate
   file stands without appeal to any other repo: the two triggers answer
   different questions, and a red run should say on sight which one asked.
2. **`secrets: inherit`, where `S01-Issuer/st0x.deploy` lists the RPC fork
   secrets explicitly** — every workflow in this repo already inherits, and an
   explicit list is a second copy of rainix's declared secret set that nothing
   keeps in sync. Concretely: rainix's `rainix-sol.yaml` on main declares ten
   secrets, seven of them `RPC_URL_*_FORK` (arbitrum, base, base_sepolia,
   ethereum, flare, **hyperevm**, polygon). That set has grown over time — I
   nearly asserted "six" in this PR from a stale local checkout that predated
   hyperevm, which is exactly the drift an explicit copy invites. With `inherit`
   there is nothing here to fall behind. Happy to switch if the least-privilege
   argument is preferred.

## Known gap this does NOT close

GitHub disables scheduled workflows in a **public** repository after 60 days
with no repository activity, and a release-frozen deploy repo is precisely the
repo that goes that quiet — the same premise that makes the sweep necessary is
what will eventually switch it off. When that happens it stops silently and has
to be re-enabled by hand. This is documented in the workflow comment and in
`CLAUDE.md` rather than papered over. Closing it properly needs an external
trigger (`repository_dispatch` from an out-of-repo cron) or a keep-alive; that
is a separate decision and is currently with the human, so no follow-up issue
has been filed.

## QA

- **Discriminating tests**: n/a — the diff is a GitHub Actions trigger plus
  prose; there is no code in this repo under it and no Solidity changed, so
  `forge test` behaviour is byte-identical. The trigger itself is only
  observable in GitHub's scheduler, and it is not observable pre-merge either:
  `gh api /repos/rainlanguage/rain.deploy/actions/workflows` lists exactly the
  three pre-existing workflows, because GitHub registers `schedule` and
  `workflow_dispatch` workflows from the **default branch** only. So a dispatch
  run on this branch is not offerable — the first real exercise is post-merge
  (`gh workflow run rainix-sol-scheduled.yaml`), and I would rather say that
  than claim a run I cannot make. `actionlint` is the strongest oracle available
  before merge, and it is mutation-proven below rather than assumed.
- **Mutations applied** (oracle `actionlint`; baseline `m0` = the committed file
  verbatim, exit 0, clean):
  - `- cron: "17 3 * * *"` -> `"17 3 * *"` -> **killed**: `invalid CRON format
    ... expected exactly 5 fields, found 4`
  - `- cron: "17 3 * * *"` -> `"17 3 * * 8"` -> **killed**: `end of range (8)
    above maximum (6)`
  - `uses: .../rainix-sol.yaml@main` -> ref dropped -> **killed**: `reusable
    workflow call ... is not following the format
    "owner/repo/path/to/workflow.yml@ref"`
  - `schedule:` -> `schedules:` -> **killed**: `unknown Webhook event
    "schedules"`
  4/4 killed, so a clean `actionlint` on the real file is evidence and not
  silence. What it cannot see, and I am not claiming: whether GitHub's scheduler
  actually fires.
- **Oracle**: GitHub Actions workflow syntax as enforced by `actionlint`, plus
  the GitHub Contents API against **default branches** for every cross-repo
  statement in this PR — `rainix-sol.yaml` being `on: workflow_call`, the
  `rainix-tag-release.yaml` drift-sweep comments, the ten declared secrets, the
  three-repo cron enumeration above, and the `S01-Issuer/st0x.deploy` file. My
  first pass sourced several of these from local working copies, which was
  wrong twice over: the st0x checkout was on a feature branch
  (`stox/deterministic-authoriser-clone`), not main, and the rainix checkout was
  stale enough to be missing `RPC_URL_HYPEREVM_FORK`. Everything cross-repo here
  is now re-read from the remote default branch. The five networks and the
  `<NETWORK>_RPC_URL` binding come from this repo's `foundry.toml`
  `[rpc_endpoints]` and rainix's `rainix-sol-test.yaml` env block.
- **Category check**: the issue asks for one thing — a scheduled trigger so the
  chain-anchored verification runs without a push — and that is covered. Its
  proposed patch shape is deliberately not followed (separate workflow, per the
  issue's own verification note); the docs that enumerate this repo's workflows
  are updated so the claim "push is the only path to `forge test`" is not left
  standing in `CLAUDE.md`/`README.md` after it stops being true.

Other checks run locally: `nix develop -c reuse lint` compliant, 72/72 files
(`.github/**` is covered by `REUSE.toml`, so the new workflow needs no header);
repo `pre-commit` hooks pass, including `yamlfmt` on the new workflow and
`denofmt` on the markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
