### PR TITLE
Refuse a post-deploy check that has no reads

### DIFF
--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -50,6 +50,11 @@ library LibRainDeploy {
     /// do not pair up.
     error ResolvedAddressesLengthMismatch(uint256 readCallsLength, uint256 expectedAddressesLength);
 
+    /// Thrown when a post-deploy check is given no reads. A check with nothing
+    /// to read passes on every network having asserted nothing, which is
+    /// indistinguishable from every read checking out.
+    error NoResolvedAddressReads(address target);
+
     /// Thrown when a post-deploy read reverts, or answers with something that is
     /// not a single address-sized word.
     error ResolvedAddressReadFailed(string network, address target, uint256 index, bytes returnData);
@@ -263,6 +268,12 @@ library LibRainDeploy {
     /// Only the consumer knows where it stored what it resolved, so the consumer
     /// supplies the reads. Each entry in `readCalls` is static-called against
     /// `target` and MUST answer with exactly one address.
+    ///
+    /// An empty read set is REFUSED. A check with nothing to read returns having
+    /// asserted nothing, which is indistinguishable from every read checking
+    /// out, and it is what a consumer that built its read list from a source
+    /// that came back empty hands in — right before it migrates onto the
+    /// deployment this was supposed to verify.
     /// @param network The network name, for the error only.
     /// @param target The deployed contract to read.
     /// @param readCalls The calldata for each read, e.g.
@@ -277,6 +288,13 @@ library LibRainDeploy {
     ) internal view {
         if (readCalls.length != expectedAddresses.length) {
             revert ResolvedAddressesLengthMismatch(readCalls.length, expectedAddresses.length);
+        }
+        // After the pairing check, not before it: an unpaired call is a
+        // mispairing whichever side is empty, and reporting the empty pair as a
+        // mismatch of zero against zero would say nothing. The empty pair is the
+        // one case pairing cannot see, so it is its own error.
+        if (readCalls.length == 0) {
+            revert NoResolvedAddressReads(target);
         }
         for (uint256 i = 0; i < readCalls.length; i++) {
             // The consumer supplies the reads, so the call is low level by
@@ -317,6 +335,10 @@ library LibRainDeploy {
     /// than expected is a burned deterministic address, found while nothing
     /// points at it yet — which is the whole reason to verify before migrating
     /// onto a deployment rather than trusting it.
+    ///
+    /// An empty network set and an empty read set are both REFUSED, before
+    /// anything is forked. Either one makes this return success across every
+    /// network having read nothing at all.
     /// @param vm The Vm instance to use for forking.
     /// @param networks The list of network names to check.
     /// @param target The deployed contract to read on each network.
@@ -337,6 +359,11 @@ library LibRainDeploy {
         // than after an RPC round trip.
         if (readCalls.length != expectedAddresses.length) {
             revert ResolvedAddressesLengthMismatch(readCalls.length, expectedAddresses.length);
+        }
+        // Same reason: an empty read set is reported without an RPC round trip,
+        // so it cannot be masked by an outage on the first network.
+        if (readCalls.length == 0) {
+            revert NoResolvedAddressReads(target);
         }
         for (uint256 i = 0; i < networks.length; i++) {
             // createSelectFork returns a fork id that is not needed here; bind

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -972,6 +972,39 @@ contract LibRainDeployTest is Test {
         this.externalCheckResolvedAddresses("test_network", address(this), readCalls, expectedAddresses);
     }
 
+    /// A check with no reads MUST be refused rather than pass. It is the same
+    /// hazard `NoNetworks` covers one argument along: an empty read set is
+    /// indistinguishable from every read checking out, and it is what a
+    /// consumer that built its read list from an empty config hands in — right
+    /// before it migrates onto the deployment this was supposed to verify.
+    function testCheckResolvedAddressesNoReadsReverts(address target) external {
+        vm.expectRevert(abi.encodeWithSelector(LibRainDeploy.NoResolvedAddressReads.selector, target));
+        this.externalCheckResolvedAddresses("test_network", target, new bytes[](0), new address[](0));
+    }
+
+    /// The refusal is about the READS, not about the pairing: an empty pair is
+    /// the one case a length mismatch cannot see, which is why it is its own
+    /// error. Empty reads against a non-empty expected list stays a mismatch,
+    /// pinning that pairing is still checked first, and a single real read
+    /// still passes, so emptiness alone is what is refused.
+    function testCheckResolvedAddressesEmptyPairIsNotALengthMismatch(bytes32 name, address account) external {
+        vm.assume(account != address(0));
+        (, MockResolvedOwner consumer) = deployRegistryAndConsumer(name, account);
+
+        vm.expectRevert(abi.encodeWithSelector(LibRainDeploy.NoResolvedAddressReads.selector, address(consumer)));
+        this.externalCheckResolvedAddresses("test_network", address(consumer), new bytes[](0), new address[](0));
+
+        // Empty reads against a non-empty expected list is a mispairing, and is
+        // still reported as one.
+        vm.expectRevert(
+            abi.encodeWithSelector(LibRainDeploy.ResolvedAddressesLengthMismatch.selector, uint256(0), uint256(1))
+        );
+        this.externalCheckResolvedAddresses("test_network", address(consumer), new bytes[](0), expected(account));
+
+        // One read still passes, so the refusal is about emptiness alone.
+        LibRainDeploy.checkResolvedAddresses("test_network", address(consumer), ownerReadCalls(), expected(account));
+    }
+
     /// `checkResolvedAddressesOnNetworks` MUST revert with `NoNetworks` when
     /// given none, so an empty target set can never be mistaken for every read
     /// checking out.
@@ -996,6 +1029,17 @@ contract LibRainDeployTest is Test {
             abi.encodeWithSelector(LibRainDeploy.ResolvedAddressesLengthMismatch.selector, uint256(2), uint256(1))
         );
         this.externalCheckResolvedAddressesOnNetworks(networks, address(this), readCalls, expectedAddresses);
+    }
+
+    /// And an empty read set is refused before any network is forked too, so it
+    /// is reported without an RPC round trip and cannot be masked by an outage.
+    function testCheckResolvedAddressesOnNetworksNoReadsRevertsBeforeForking() external {
+        string[] memory networks = new string[](1);
+        // Not a configured RPC alias, so forking it is itself an error.
+        networks[0] = "unconfigured_network";
+
+        vm.expectRevert(abi.encodeWithSelector(LibRainDeploy.NoResolvedAddressReads.selector, address(this)));
+        this.externalCheckResolvedAddressesOnNetworks(networks, address(this), new bytes[](0), new address[](0));
     }
 
     /// `checkResolvedAddressesOnNetworks` MUST fork each network in turn and


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/61 (audit finding `cov-08`).

## The hole

`LibRainDeploy.checkResolvedAddresses` guarded only that `readCalls` and `expectedAddresses` pair up, then looped over them:

```solidity
if (readCalls.length != expectedAddresses.length) { revert ResolvedAddressesLengthMismatch(...); }
for (uint256 i = 0; i < readCalls.length; i++) { ... }
```

With both lengths zero the pairing guard passes and the loop body never runs, so the function returns having asserted nothing. `checkResolvedAddressesOnNetworks` then forks every network, logs `Checking resolved addresses on network: …` for each, and returns success across all of them having read nothing at all.

That is the same hazard `NoNetworks` already exists for one argument along — its own test says "an empty target set can never be mistaken for every read checking out" — and the read list had no equivalent. A consumer that builds `readCalls` from a source that came back empty (a config, a loop over resolved names) gets a green "verified on every network" immediately before migrating onto that deployment.

Nothing pinned it either way: `testCheckResolvedAddressesLengthMismatchReverts` fuzzes under `vm.assume(readCallsLength != expectedLength)`, so equal-and-zero is excluded by construction, and every other call site passed a one- or two-element list.

## The fix

New error, fail-closed on the empty read set, matching the `NoNetworks` / `NoDeployCandidates` house rule:

```solidity
error NoResolvedAddressReads(address target);
```

**The guard runs after the pairing check, not before it.** An unpaired call is a mispairing whichever side happens to be empty, and reporting the empty pair as a "mismatch of zero against zero" would say nothing. So `(0, n)` stays a `ResolvedAddressesLengthMismatch` naming both lengths, and only the empty PAIR — the one case pairing cannot see — raises the new error. Hoisting it above the pairing check would swallow real mispairings; mutant M4 below is exactly that placement, and it is killed.

`checkResolvedAddressesOnNetworks` repeats the guard before its fork loop, for the reason it already repeats the pairing check there: an empty read set is reported without an RPC round trip, so a network outage cannot mask it.

## Tests

Three new tests in `test/src/lib/LibRainDeploy.t.sol`:

- `testCheckResolvedAddressesNoReadsReverts` — an empty read set is refused rather than passing.
- `testCheckResolvedAddressesEmptyPairIsNotALengthMismatch` — the empty pair raises the new error, empty-reads-against-a-non-empty-expected-list is still `ResolvedAddressesLengthMismatch(0, 1)`, and one real read still passes. The middle assertion deterministically pins the guard ORDER rather than leaving it to whether the fuzzer happens to draw a zero.
- `testCheckResolvedAddressesOnNetworksNoReadsRevertsBeforeForking` — refused before anything is forked, using an unconfigured RPC alias so reaching the fork loop is itself an error.

The pre-existing `testCheckResolvedAddressesLengthMismatchReverts` fuzz test is unchanged and still passes, which is the point of the ordering.

## QA
- Discriminating tests: `testCheckResolvedAddressesNoReadsReverts`, `testCheckResolvedAddressesEmptyPairIsNotALengthMismatch`, `testCheckResolvedAddressesOnNetworksNoReadsRevertsBeforeForking` — each fails on base. Verified via mutants M1 and M5, which delete the added guards and so reproduce base behaviour exactly (literal base does not compile these tests, since `NoResolvedAddressReads` does not exist there); with the guard deleted, M1 is killed by the first two and M5 by the third.
- Mutations applied: 6 mutants via `mutation-probe`, **6/6 KILLED, 0 survived, 0 no-run, 0 harness errors**, against a green 13-test baseline.
  - M1 `checkResolvedAddresses`: delete the empty-read guard entirely → `testCheckResolvedAddressesNoReadsReverts`, `testCheckResolvedAddressesEmptyPairIsNotALengthMismatch`
  - M2 `checkResolvedAddresses`: `readCalls.length == 0` → `== 1` → `testCheckResolvedAddressesNoReadsReverts`, `…Match`, `…MismatchReverts`, `…DirtyWordReverts`, `…EmptyPairIsNotALengthMismatch`
  - M3 `checkResolvedAddresses`: `NoResolvedAddressReads(target)` → `(address(0))` → `testCheckResolvedAddressesNoReadsReverts`, `testCheckResolvedAddressesEmptyPairIsNotALengthMismatch`
  - M4 `checkResolvedAddresses`: hoist the guard ABOVE the pairing check → `testCheckResolvedAddressesEmptyPairIsNotALengthMismatch` (deterministic) and `testCheckResolvedAddressesLengthMismatchReverts` (fuzz-dependent — it needs the fuzzer to draw `readCallsLength == 0`, which is why the deterministic assertion was added rather than relying on it)
  - M5 `checkResolvedAddressesOnNetworks`: delete the pre-fork empty-read guard → `testCheckResolvedAddressesOnNetworksNoReadsRevertsBeforeForking`
  - M6 `checkResolvedAddressesOnNetworks`: `NoResolvedAddressReads(target)` → `(address(0))` → `testCheckResolvedAddressesOnNetworksNoReadsRevertsBeforeForking`
  - The probe suite is deliberately scoped network-free (`--match-test CheckResolvedAddresses` minus the two fork tests) and was run with no `.env` present at all, so nothing in it can reach an RPC. A first pass over the full `forge test` produced 6/6 "killed" whose named killers were fork tests (`testChainMatrix*`, `testDeployToNetworks*`) that a guard inside `checkResolvedAddresses` cannot affect — flaky public-RPC failures being scored as kills. That matrix was discarded as untrustworthy rather than reported.
- Oracle: the invariant is stated independently of this implementation — an assertion helper that asserts nothing must not report success, which is the rule `NoNetworks` already encodes one argument along and `NoDeployCandidates` encodes for the candidate list ("a candidate the loop never reaches is a contract whose snapshot nothing anywhere anchors"). Expected revert data is built from the error signature via `abi.encodeWithSelector`, not read back from a run.
- Category check: the issue asks for (a) a fail-closed error on the empty read set, (b) the guard in `checkResolvedAddresses`, (c) the guard before the fork loop in `checkResolvedAddressesOnNetworks`, (d) tests covering all three. All four covered. One deliberate deviation from the issue's proposed patch, which the issue's own verification block flagged: the guard is placed AFTER the pairing check, not before it, so the existing length-mismatch fuzz test keeps its meaning for `(0, n)`.

Full suite green: 218 passed, 0 failed, 17 suites. `forge fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject resolved-address checks when no reads are supplied.
  * Empty read sets now fail before network reads or fork creation.
  * Preserved distinct errors for empty inputs versus mismatched read and expected-value lists.

* **Tests**
  * Added coverage for empty inputs, mismatched lists, valid reads, and multi-network validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->