### PR TITLE
test(build): cover the generator's declaration and the alias-lib emitter

### DIFF
--- a/test/concrete/BuildHarness.sol
+++ b/test/concrete/BuildHarness.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Build, GeneratedContract} from "../../script/Build.sol";
+import {DeployCandidate} from "../../src/abstract/RainDeploySuitesBase.sol";
+
+/// @title BuildHarness
+/// @notice An external seam onto the two internal declarations `BuildTest`
+/// compares, so a test can hold both at once.
+///
+/// A harness rather than a change to `Build`: `generatedContracts()` is the
+/// script's own declaration and has no caller outside it, and widening it to
+/// `public` to be testable would put a second entry point on a script whose
+/// whole surface is `run()` and `cutRelease()`.
+contract BuildHarness is Build {
+    /// The generator's list.
+    /// @return The generated contracts.
+    function externalGeneratedContracts() external pure returns (GeneratedContract[] memory) {
+        return generatedContracts();
+    }
+
+    /// The deploy declaration's list, through the same guarded reader every
+    /// other consumer of the declaration uses.
+    /// @return The declared candidates.
+    function externalCandidateSuites() external pure returns (DeployCandidate[] memory) {
+        return checkedCandidateSuites();
+    }
+}

--- a/test/script/Build.t.sol
+++ b/test/script/Build.t.sol
@@ -3,31 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {Build, GeneratedContract} from "../../script/Build.sol";
+import {GeneratedContract} from "../../script/Build.sol";
 import {DeployCandidate} from "../../src/abstract/RainDeploySuitesBase.sol";
-
-/// @title BuildHarness
-/// @notice An external seam onto the two internal declarations, so a test can
-/// hold both at once and compare them.
-///
-/// A harness rather than a change to `Build`: `generatedContracts()` is the
-/// script's own declaration and has no caller outside it, and widening it to
-/// `public` to be testable would put a second entry point on a script whose
-/// whole surface is `run()` and `cutRelease()`.
-contract BuildHarness is Build {
-    /// The generator's list.
-    /// @return The generated contracts.
-    function externalGeneratedContracts() external pure returns (GeneratedContract[] memory) {
-        return generatedContracts();
-    }
-
-    /// The deploy declaration's list, through the same guarded reader every
-    /// other consumer of the declaration uses.
-    /// @return The declared candidates.
-    function externalCandidateSuites() external pure returns (DeployCandidate[] memory) {
-        return checkedCandidateSuites();
-    }
-}
+import {BuildHarness} from "../concrete/BuildHarness.sol";
 
 /// @title BuildTest
 /// @notice `script/Build.sol`'s own declaration.

--- a/test/script/Build.t.sol
+++ b/test/script/Build.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Build, GeneratedContract} from "../../script/Build.sol";
+import {DeployCandidate} from "../../src/abstract/RainDeploySuitesBase.sol";
+
+/// @title BuildHarness
+/// @notice An external seam onto the two internal declarations, so a test can
+/// hold both at once and compare them.
+///
+/// A harness rather than a change to `Build`: `generatedContracts()` is the
+/// script's own declaration and has no caller outside it, and widening it to
+/// `public` to be testable would put a second entry point on a script whose
+/// whole surface is `run()` and `cutRelease()`.
+contract BuildHarness is Build {
+    /// The generator's list.
+    /// @return The generated contracts.
+    function externalGeneratedContracts() external pure returns (GeneratedContract[] memory) {
+        return generatedContracts();
+    }
+
+    /// The deploy declaration's list, through the same guarded reader every
+    /// other consumer of the declaration uses.
+    /// @return The declared candidates.
+    function externalCandidateSuites() external pure returns (DeployCandidate[] memory) {
+        return checkedCandidateSuites();
+    }
+}
+
+/// @title BuildTest
+/// @notice `script/Build.sol`'s own declaration.
+///
+/// `Build`'s NatSpec argues that "one list, three readers" makes a contract
+/// silently absent from a release impossible. That is true of the readers
+/// INSIDE `Build` — the regeneration, both lib writers and the freeze all read
+/// `generatedContracts()` — and false of the boundary: what this repo deploys
+/// is declared in `RegistryDeploySuites.candidateSuites()`, and the generator's
+/// list is a second hard-coded array in a second file.
+///
+/// A candidate dropped from `generatedContracts()` by a refactor or a merge
+/// still compiles, because its committed snapshot is still there and still
+/// imported. `cutRelease()` then freezes only the contracts the generator
+/// names, `regenerateLibs()` writes a released-suites lib only for those, and
+/// the release permanently omits that contract. Nothing downstream can see it:
+/// `testEveryFrozenSnapshotIsReleased` walks record -> declaration, so a record
+/// entry never written is invisible to it; `RegistryDeployChainTest` is never
+/// handed the omitted suite; and `testEveryCandidateHasASnapshot` compares the
+/// candidate DIRECTORY against the declaration, where the stale committed file
+/// keeps both sides equal. `SnapshotAlreadyFrozen` then makes the hole
+/// unrepairable, because the tag has been cut.
+///
+/// So the agreement of the two lists is asserted here, along with the three
+/// properties of the generator's own entries that decide which file each
+/// contract's pins are written into.
+///
+/// Deliberately nothing here calls `run()` or `cutRelease()`. Both write
+/// `src/lib/Lib*Released.sol`, which `LibRainDeploySnapshotTest` also writes,
+/// and forge runs test contracts in parallel — two contracts writing one file
+/// is a race, not a check. Everything below is pure.
+contract BuildTest is Test {
+    /// The harness the two declarations are read through.
+    BuildHarness internal sBuild;
+
+    function setUp() external {
+        sBuild = new BuildHarness();
+    }
+
+    /// PROPERTY: the generator's list and the deploy declaration are the SAME
+    /// SET of contracts, matched both ways. A candidate the generator does not
+    /// name is a contract silently absent from every release cut from here, and
+    /// neither the frozen-record check nor the chain check can see it, because
+    /// both are only ever handed what was written.
+    ///
+    /// Matched by the suite key rather than by index, because `Build` reaches
+    /// candidates by name for exactly this reason and a positional pass would
+    /// go green on a reordered list that had silently swapped two contracts.
+    function testGeneratedContractsAreExactlyTheDeclaredCandidates() external view {
+        GeneratedContract[] memory generated = sBuild.externalGeneratedContracts();
+        DeployCandidate[] memory candidates = sBuild.externalCandidateSuites();
+
+        assertEq(
+            generated.length, candidates.length, "a candidate is not generated, or a generated contract is not declared"
+        );
+
+        for (uint256 i = 0; i < generated.length; i++) {
+            bool found = false;
+            for (uint256 j = 0; j < candidates.length; j++) {
+                if (
+                    keccak256(bytes(generated[i].candidate.snapshot.suite))
+                        == keccak256(bytes(candidates[j].snapshot.suite))
+                ) {
+                    assertEq(
+                        keccak256(generated[i].candidate.snapshot.creationCode),
+                        keccak256(candidates[j].snapshot.creationCode),
+                        "generated entry carries another contract's creation code"
+                    );
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(
+                found, string.concat("generated contract is not a declared candidate: ", generated[i].contractName)
+            );
+        }
+
+        for (uint256 j = 0; j < candidates.length; j++) {
+            bool found = false;
+            for (uint256 i = 0; i < generated.length; i++) {
+                if (
+                    keccak256(bytes(generated[i].candidate.snapshot.suite))
+                        == keccak256(bytes(candidates[j].snapshot.suite))
+                ) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found, string.concat("declared candidate is not generated: ", candidates[j].snapshot.suite));
+        }
+    }
+
+    /// PROPERTY: `contractName` is the name the snapshot path and both
+    /// generated libs are built from, and it MUST be the contract the
+    /// candidate's artifact path names. A disagreement writes one contract's
+    /// pins into another contract's file, which every downstream check then
+    /// reads as self-consistent.
+    function testGeneratedContractNameMatchesTheArtifactPath() external view {
+        GeneratedContract[] memory generated = sBuild.externalGeneratedContracts();
+        for (uint256 i = 0; i < generated.length; i++) {
+            string[] memory components = vm.split(generated[i].candidate.snapshot.artifactPath, ":");
+            assertEq(
+                components[components.length - 1],
+                generated[i].contractName,
+                "generated name is not the artifact's contract"
+            );
+        }
+    }
+
+    /// PROPERTY: no two entries name one contract. Two entries sharing a
+    /// `contractName` write one snapshot file twice and freeze one file for two
+    /// declarations, so the second silently replaces the first.
+    function testGeneratedContractNamesAreUnique() external view {
+        GeneratedContract[] memory generated = sBuild.externalGeneratedContracts();
+        for (uint256 i = 0; i < generated.length; i++) {
+            for (uint256 j = i + 1; j < generated.length; j++) {
+                assertNotEq(
+                    generated[i].contractName, generated[j].contractName, "two generated entries name one contract"
+                );
+            }
+        }
+    }
+
+    /// PROPERTY: the constant prefix is non-empty and distinct per contract. It
+    /// names every constant both generated libs export, so a shared prefix is
+    /// two libs exporting colliding names.
+    function testConstantPrefixesAreNonEmptyAndUnique() external view {
+        GeneratedContract[] memory generated = sBuild.externalGeneratedContracts();
+        for (uint256 i = 0; i < generated.length; i++) {
+            assertGt(bytes(generated[i].constantPrefix).length, 0, "empty constant prefix");
+            for (uint256 j = i + 1; j < generated.length; j++) {
+                assertNotEq(
+                    generated[i].constantPrefix, generated[j].constantPrefix, "two entries share a constant prefix"
+                );
+            }
+        }
+    }
+}

--- a/test/src/lib/LibRainDeploySnapshot.t.sol
+++ b/test/src/lib/LibRainDeploySnapshot.t.sol
@@ -229,6 +229,103 @@ contract LibRainDeploySnapshotTest is Test {
         assertTrue(exists);
     }
 
+    /// The alias lib this repo's `AddressRegistry` snapshot is re-exported
+    /// through, and the only file the alias emitter writes here.
+    ///
+    /// `writeAliasLib` derives its path from the contract name and takes no
+    /// root, so driving it against a real contract writes the COMMITTED file.
+    /// That is what makes an alias lib whose text has drifted from what the
+    /// generator emits a failure rather than a diff nobody looks at — and the
+    /// alias emitter is otherwise the one generator path in this repo that
+    /// nothing anywhere executes, because only `script/Build.sol` calls it and
+    /// nothing may call that.
+    string constant ALIAS_LIB_PATH = "src/lib/LibAddressRegistryDeploy.sol";
+
+    /// The import block MUST alias exactly the two pins an alias lib
+    /// re-exports, out of the snapshot directory it is pointed at.
+    ///
+    /// Both constants are renamed on import because the lib exports its own
+    /// names for them in the same file, so a dropped alias is not a compile
+    /// error but a constant silently bound to whatever else is in scope. All
+    /// three parameters are asserted to reach the output distinctly: a block
+    /// that ignored `dir` would alias the rolling snapshot forever, including
+    /// where a frozen tag was asked for.
+    function testAliasImportBlockAliasesBothPins() external pure {
+        assertEq(
+            LibRainDeploySnapshot.aliasImportBlock(
+                "AddressRegistry", "ADDRESS_REGISTRY", LibRainDeploySnapshot.CANDIDATE
+            ),
+            "import {\n" "    DEPLOYED_ADDRESS as ADDRESS_REGISTRY_ADDR,\n"
+            "    BYTECODE_HASH as ADDRESS_REGISTRY_HASH\n" "} from \"../generated/candidate/AddressRegistry.sol\";\n\n"
+        );
+
+        assertEq(
+            LibRainDeploySnapshot.aliasImportBlock("MockDeployable", "MOCK_DEPLOYABLE", "0_1_7"),
+            "import {\n" "    DEPLOYED_ADDRESS as MOCK_DEPLOYABLE_ADDR,\n" "    BYTECODE_HASH as MOCK_DEPLOYABLE_HASH\n"
+            "} from \"../generated/0_1_7/MockDeployable.sol\";\n\n"
+        );
+    }
+
+    /// The library block MUST re-export BOTH pins under the consumer-facing
+    /// names, from the aliases the import block bound.
+    ///
+    /// The address and the code hash are what every consumer of this repo
+    /// resolves and verifies against, and they are the whole content of the
+    /// file. A block that emitted one of them, or bound one to the other's
+    /// alias, is a lib that compiles and lies.
+    function testAliasLibraryBlockReExportsBothPins() external pure {
+        assertEq(
+            LibRainDeploySnapshot.aliasLibraryBlock("AddressRegistry", "ADDRESS_REGISTRY", "LibAddressRegistryDeploy"),
+            "/// @title LibAddressRegistryDeploy\n"
+            "/// @notice The deterministic Zoltu deploy address and code hash of\n"
+            "/// `AddressRegistry`, aliased from its generated snapshot so that snapshot stays the\n"
+            "/// single source of truth. The import path never moves, so consumers are\n"
+            "/// unaffected by which snapshot it names.\n" "library LibAddressRegistryDeploy {\n"
+            "    address constant ADDRESS_REGISTRY_DEPLOYED_ADDRESS = ADDRESS_REGISTRY_ADDR;\n"
+            "    bytes32 constant ADDRESS_REGISTRY_DEPLOYED_CODEHASH = ADDRESS_REGISTRY_HASH;\n" "}\n"
+        );
+
+        assertEq(
+            LibRainDeploySnapshot.aliasLibraryBlock("MockDeployable", "MOCK_DEPLOYABLE", "LibMockDeployableDeploy"),
+            "/// @title LibMockDeployableDeploy\n"
+            "/// @notice The deterministic Zoltu deploy address and code hash of\n"
+            "/// `MockDeployable`, aliased from its generated snapshot so that snapshot stays the\n"
+            "/// single source of truth. The import path never moves, so consumers are\n"
+            "/// unaffected by which snapshot it names.\n" "library LibMockDeployableDeploy {\n"
+            "    address constant MOCK_DEPLOYABLE_DEPLOYED_ADDRESS = MOCK_DEPLOYABLE_ADDR;\n"
+            "    bytes32 constant MOCK_DEPLOYABLE_DEPLOYED_CODEHASH = MOCK_DEPLOYABLE_HASH;\n" "}\n"
+        );
+    }
+
+    /// The alias lib MUST land at the path derived from the contract name,
+    /// holding exactly the header, import block and library block the emitters
+    /// produce.
+    ///
+    /// Run against this repo's REAL contract and its real rolling snapshot, so
+    /// what it writes is the committed generated file and the assertion is that
+    /// the committed file IS what the generator emits today. Nothing else in
+    /// the suite can see that: the alias lib's VALUES are anchored by the pins
+    /// tests that read them, and its TEXT by nothing at all.
+    ///
+    /// Restored BEFORE the assertions run, because forge-std assertions revert:
+    /// restoring afterwards restores in every case except a failure, which is
+    /// the only case where the tree is dirty and the one this test exists to
+    /// report.
+    function testWriteAliasLibWritesTheLibAtItsPath() external {
+        string memory before = vm.readFile(ALIAS_LIB_PATH);
+
+        string memory written = LibRainDeploySnapshot.writeAliasLib(
+            vm, "AddressRegistry", "ADDRESS_REGISTRY", LibRainDeploySnapshot.CANDIDATE
+        );
+        string memory emitted = vm.readFile(ALIAS_LIB_PATH);
+
+        //forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.writeFile(ALIAS_LIB_PATH, before);
+
+        assertEq(written, ALIAS_LIB_PATH);
+        assertEq(emitted, before);
+    }
+
     /// Where the released-lib record fixture is built. Its own tree rather
     /// than `FIXTURE_ROOT`: forge runs the tests in a contract concurrently,
     /// and two of them writing one record root see each other's releases.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/45.
Closes https://github.com/rainlanguage/rain.deploy/issues/57 — the alias-lib emitter tests below (`testAliasImportBlockAliasesBothPins`, `testAliasLibraryBlockReExportsBothPins`, `testWriteAliasLibWritesTheLibAtItsPath`) are that issue in full.

Tests only. No `src/` or `script/` source change.

## What was actually uncovered

The issue carries two findings on `script/Build.sol`, and their two proposed
fixes contradict each other. `DEPLOY-3`'s verification says a test must
deliberately NOT invoke `run()`/`cutRelease()`; `cov-01`'s proposed fix is
built entirely around calling `run()`. This PR implements `DEPLOY-3` as
written and implements `cov-01` as its own verification block narrowed it,
which is not what its proposed-fix section says.

### `DEPLOY-3` — the two lists

`generatedContracts()` and `RegistryDeploySuites.candidateSuites()` are two
hard-coded arrays in two files. A candidate dropped from the generator by a
refactor or a merge still compiles, because its committed snapshot is still
there and still imported. `cutRelease()` then freezes only what the generator
names, `regenerateLibs()` writes a released-suites lib only for those, and the
release permanently omits that contract — `SnapshotAlreadyFrozen` makes the
hole unrepairable once the tag is cut.

Nothing downstream could see it. `testEveryFrozenSnapshotIsReleased` walks
record -> declaration, so a record entry never written is invisible to it.
`RegistryDeployChainTest` is never handed the omitted suite.
`testEveryCandidateHasASnapshot` compares the candidate DIRECTORY against the
declaration, and the stale committed file keeps both sides equal.

`test/script/Build.t.sol` asserts the two lists are the same SET, matched by
suite key in both directions, plus the three properties of the generator's own
entries that decide which file each contract's pins land in.

### `cov-01` — narrowed to the alias-lib emitter

`cov-01`'s verification corrected it MEDIUM -> LOW and refuted two of its three
consequences: `generatedContracts()` is not a second declaration of the
metadata, and the candidate snapshots and released libs are already anchored by
three test groups. What survived is one thing — `writeAliasLib`,
`aliasImportBlock` and `aliasLibraryBlock` are referenced by nothing outside
their own file, the only generator path here with zero execution by the suite,
so the committed `src/lib/Lib*Deploy.sol` was never proven to be what the
generator emits.

Closed in `test/src/lib/LibRainDeploySnapshot.t.sol` the way this repo already
closes exactly this shape: the two block emitters are pinned against literal
expected text, and `writeAliasLib` is driven against the REAL contract and
compared to the committed file, restored BEFORE the assertions because
forge-std assertions revert.

## Why nothing calls `run()` or `cutRelease()`

`run()` writes `src/lib/LibAddressRegistryReleased.sol`, which
`LibRainDeploySnapshotTest.testWriteReleasedSuitesLibWritesTheLibAtItsPath`
already reads, writes and restores. forge runs test contracts in parallel, so a
second writer of that file is a race — and one that yields flaky reds, not a
check. The alias test added here writes `Lib*Deploy.sol`, which no other test
writes and which every other reference to resolves as a compile-time symbol
import, so it adds no contended file.

`cov-01` also names `run()`'s two-step sequencing as unexercised. That
sequencing is not load-bearing: `regenerateLibs` reads nothing
`regenerateCandidates` writes. The alias libs are pure text from names, and the
released libs read only tag-shaped directories — `frozenSnapshotPaths` filters
on `isTag`, so `candidate/` falls out. The ordering that IS load-bearing is
`cutRelease()`'s, and `freeze` already enforces it structurally by taking
`regenerate` as a function pointer and running it first.

## Gates

- 175 pass / 47 fail, against a 168 / 47 baseline on `main`. All 47 are the
  pre-existing `vm.createSelectFork` failures from unset `*_RPC_URL`; neither
  the count nor the membership moved.
- `forge build` clean, `forge fmt --check` clean, `reuse lint` compliant,
  `pre-commit run --all-files` passing.

## QA

- Discriminating tests:
  `testGeneratedContractsAreExactlyTheDeclaredCandidates`,
  `testGeneratedContractNameMatchesTheArtifactPath`,
  `testGeneratedContractNamesAreUnique`,
  `testConstantPrefixesAreNonEmptyAndUnique`,
  `testAliasImportBlockAliasesBothPins`,
  `testAliasLibraryBlockReExportsBothPins`,
  `testWriteAliasLibWritesTheLibAtItsPath`.
  All seven are new, so all seven fail on base by not existing; each was
  additionally verified to fail on a break of the specific thing it guards,
  with the mutation applied to committed source and reverted after (table
  below). The last three in the alias set are mutually discriminating: the two
  pure block tests survive the `filePrefix()`, path-derivation and hand-edit
  mutations, and only the write test kills them.

- Mutations applied (line -> mutation -> killing test):
  - `script/Build.sol:83,87-91` -> `MigrationRegistry` entry deleted, length
    2 -> 1 -> `testGeneratedContractsAreExactlyTheDeclaredCandidates`
    (`a candidate is not generated, or a generated contract is not declared: 1 != 2`)
  - `script/Build.sol:87-91` -> entry 1 keeps `MigrationRegistry` but carries
    `addressRegistryCandidate()` ->
    `testGeneratedContractsAreExactlyTheDeclaredCandidates`
    (`declared candidate is not generated: migration-registry`)
  - `script/Build.sol:88` -> `contractName` -> `MigrationRegistryV2` ->
    `testGeneratedContractNameMatchesTheArtifactPath`
    (`generated name is not the artifact's contract`)
  - `script/Build.sol:85,88` -> both entries named `AddressRegistry` ->
    `testGeneratedContractNamesAreUnique`
    (`two generated entries name one contract`)
  - `script/Build.sol:89` -> `constantPrefix` emptied ->
    `testConstantPrefixesAreNonEmptyAndUnique` (`empty constant prefix`)
  - `script/Build.sol:85,89` -> both entries share `ADDRESS_REGISTRY` ->
    `testConstantPrefixesAreNonEmptyAndUnique`
    (`two entries share a constant prefix`)
  - `src/lib/LibRainDeploySnapshot.sol:313` -> `BYTECODE_HASH` alias dropped
    from `aliasImportBlock` -> `testAliasImportBlockAliasesBothPins` AND
    `testWriteAliasLibWritesTheLibAtItsPath`
  - `src/lib/LibRainDeploySnapshot.sol:346` -> `_DEPLOYED_CODEHASH` bound to
    `_ADDR` -> `testAliasLibraryBlockReExportsBothPins` AND
    `testWriteAliasLibWritesTheLibAtItsPath`
  - `src/lib/LibRainDeploySnapshot.sol:390` -> `LibCodeGen.filePrefix()`
    dropped from the concat -> ONLY
    `testWriteAliasLibWritesTheLibAtItsPath` (emitted file starts at
    `import {`)
  - `src/lib/LibRainDeploySnapshot.sol:384` -> path derived as
    `Lib<Contract>Deployed` -> ONLY
    `testWriteAliasLibWritesTheLibAtItsPath`
    (`LibAddressRegistryDeployed.sol != LibAddressRegistryDeploy.sol`)
  - `src/lib/LibAddressRegistryDeploy.sol` (the COMMITTED generated file)
    -> a doc line hand-edited -> ONLY
    `testWriteAliasLibWritesTheLibAtItsPath`, full-file string diff. This is
    the case `cov-01` exists for: a hand-edited generated file is now a test
    failure.

  Nothing survived its own mutation. Tree confirmed clean after every revert.

- Oracle: independent of the implementation in all three cases.
  - The list-agreement property's oracle is `checkedCandidateSuites()` — the
    deploy declaration, a different file from the generator's list, which is
    the whole point of the finding.
  - `contractName`'s oracle is the candidate's own `artifactPath`, split on
    `":"`, not the generator's own name field.
  - The alias emitters' oracle is literal expected text written out in the
    test, NOT reconstructed from the emitters under test. This matters: the
    pre-existing `testWriteReleasedSuitesLibWritesTheLibAtItsPath` builds its
    expectation by calling the same `releasedImportBlock`/`releasedLibraryBlock`
    the writer calls, so a mutation there moves both sides and survives. The
    alias tests avoid that, and `testWriteAliasLibWritesTheLibAtItsPath`'s
    oracle is the committed file on disk, which is fixed independently of any
    emitter change.

- Category check: the issue asks for (A) coverage of `script/Build.sol`, which
  had none, (B) an assertion that `generatedContracts()` covers every declared
  candidate, and (C) `cov-01`'s coverage gap. Covered A and B in
  `test/script/Build.t.sol`. Covered C as its own verification block narrowed
  it — the alias-lib emitter — and NOT as its proposed-fix section wrote it,
  because that section calls `run()`, which `DEPLOY-3`'s verification block in
  the same issue rules out as a parallel-write race. The `cutRelease()` write
  path is explicitly deferred by the issue itself to cov-02/cov-03, which need
  `freeze` to take a record root; it is out of scope here and stays uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

