### PR TITLE
test: drive checkFrozenSnapshotsReleased over a multi-file record

### DIFF
--- a/test/src/abstract/RainDeployVerifySnapshot.t.sol
+++ b/test/src/abstract/RainDeployVerifySnapshot.t.sol
@@ -87,6 +87,17 @@ contract RainDeployVerifySnapshotTest is ExampleDeploySuites, RainDeployVerifySn
         paths[0] = LibRainDeploySnapshot.pathForSnapshot(LibRainDeploySnapshot.CANDIDATE, "AddressRegistry");
     }
 
+    /// A record of BOTH committed snapshots. `AddressRegistry` is what the
+    /// exemplar's first released suite derives; `MigrationRegistry` is declared
+    /// by no released suite here, so it is a real record file that really is
+    /// undeclared, and the undeclared one is the LAST.
+    /// @return paths The two-file record.
+    function recordOfBothGeneratedSnapshots() internal pure returns (string[] memory paths) {
+        paths = new string[](2);
+        paths[0] = LibRainDeploySnapshot.pathForSnapshot(LibRainDeploySnapshot.CANDIDATE, "AddressRegistry");
+        paths[1] = LibRainDeploySnapshot.pathForSnapshot(LibRainDeploySnapshot.CANDIDATE, "MigrationRegistry");
+    }
+
     /// A record declared by a released suite MUST pass, so the failing cases
     /// below are discriminating rather than a check that cannot succeed.
     function testFrozenSnapshotDeclaredPasses() external view {
@@ -212,6 +223,73 @@ contract RainDeployVerifySnapshotTest is ExampleDeploySuites, RainDeployVerifySn
 
         vm.expectRevert(abi.encodeWithSelector(FrozenSnapshotUnreadable.selector, paths[0]));
         this.externalCheckFrozenSnapshotsReleased(paths, releasedSuites());
+    }
+
+    /// EVERY file in the record MUST be checked, not just the first. The
+    /// undeclared file here is the LAST one, behind a declared one, so a loop
+    /// that stopped after the first path would pass — and a release that
+    /// dropped out of the declaration is exactly what this check exists to
+    /// catch, on a record that grows one file per release.
+    function testFrozenSnapshotCheckReachesEveryRecordFile() external {
+        // The first really is declared, so nothing fails before the loop has to
+        // advance.
+        string[] memory first = new string[](1);
+        first[0] = recordOfBothGeneratedSnapshots()[0];
+        this.externalCheckFrozenSnapshotsReleased(first, releasedSuites());
+
+        vm.expectRevert(abi.encodeWithSelector(FrozenSnapshotNotReleased.selector, recordOfBothGeneratedSnapshots()[1]));
+        this.externalCheckFrozenSnapshotsReleased(recordOfBothGeneratedSnapshots(), releasedSuites());
+    }
+
+    /// An unreadable file MUST be named as the file the loop is ON. Its path is
+    /// carried into the read for that error alone, so a loop that advanced but
+    /// kept handing the read `paths[0]` would send the reader to a file that
+    /// reads perfectly well — and every position after the first is where a
+    /// record spends its life from the second release onward.
+    function testFrozenSnapshotUnreadableFileIsNamedAtEveryRecordPosition() external {
+        string[] memory paths = new string[](2);
+        // Declared and readable, so nothing fails before the loop has to
+        // advance.
+        paths[0] = recordOfTheGeneratedSnapshot()[0];
+        paths[1] = "src/concrete/AddressRegistry.sol";
+
+        vm.expectRevert(abi.encodeWithSelector(FrozenSnapshotUnreadable.selector, paths[1]));
+        this.externalCheckFrozenSnapshotsReleased(paths, releasedSuites());
+    }
+
+    /// The inner search MUST reach every released suite, not just the first.
+    /// The suite that declares the record here is the LAST one, so a match that
+    /// only ever looked at `released[0]` would report a declared release as
+    /// undeclared and make the check unusable the moment a repo releases twice.
+    function testFrozenSnapshotCheckReachesEveryReleasedSuite() external view {
+        DeploySuite[] memory released = releasedSuites();
+        // `second-address` first, `address-registry-0-0-1` second.
+        DeploySuite[] memory reordered = new DeploySuite[](2);
+        reordered[0] = released[1];
+        reordered[1] = released[0];
+        assertEq(reordered[1].suite, "address-registry-0-0-1");
+
+        this.externalCheckFrozenSnapshotsReleased(recordOfTheGeneratedSnapshot(), reordered);
+    }
+
+    /// An empty declaration against a record with several files fails on the
+    /// FIRST file, naming it: a repo that declared nothing is not a repo with
+    /// nothing frozen, and the file it names is the one it is on rather than
+    /// the last one in the record.
+    function testFrozenSnapshotEmptyDeclarationFailsOnTheFirstRecordFile() external {
+        vm.expectRevert(abi.encodeWithSelector(FrozenSnapshotNotReleased.selector, recordOfBothGeneratedSnapshots()[0]));
+        this.externalCheckFrozenSnapshotsReleased(recordOfBothGeneratedSnapshots(), new DeploySuite[](0));
+    }
+
+    /// A record with no files at all is a repo that has released nothing —
+    /// which is this repo's own state — and MUST pass rather than fail on a
+    /// declaration it has nothing to check against. This is the deliberate
+    /// opposite of the source anchor, which refuses an empty candidate list:
+    /// there, an empty list is a repo whose snapshots nothing anchors; here, it
+    /// is a repo that has frozen nothing yet.
+    function testFrozenSnapshotEmptyRecordPasses() external view {
+        this.externalCheckFrozenSnapshotsReleased(new string[](0), releasedSuites());
+        this.externalCheckFrozenSnapshotsReleased(new string[](0), new DeploySuite[](0));
     }
 
     /// A consistent snapshot of the WRONG contract: every recorded field is


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/59 (audit finding `cov-06`).

## The gap

`checkFrozenSnapshotsReleased` (`src/abstract/RainDeployVerifySnapshot.sol:193-209`) loops over `paths` (outer) and `released` (inner). Every driver handed it a one-element `paths`:

- `recordOfTheGeneratedSnapshot()` is `new string[](1)`, used by three tests;
- `testFrozenSnapshotWithoutADeployedAddressReverts` builds its own `new string[](1)`;
- the inherited `testEveryFrozenSnapshotIsReleased` passes `frozenSnapshotPaths(vm, LIB_FS_ROOT)`, which is a ZERO-element array here — `src/generated/` holds only `candidate/`, and `isTag` filters it out.

So a loop that stopped after its first iteration passed everything. Measured, not asserted: appending a `break` to the end of the outer loop body SURVIVES main's whole 215-test suite.

That matters on this check specifically. It is the one whose subject grows one file per release per contract, so the second entry is the ordinary case from the first release onward, and it is what makes group 4's scope complete — a release it never reaches is a release that drops out of every assertion there is, silently and permanently.

## The fix

Tests only. `src/abstract/RainDeployVerifySnapshot.sol` is byte-identical to `main` (sha256 `0ea95fda…`).

`recordOfBothGeneratedSnapshots()` builds a two-file record from this repo's own committed snapshots, so nothing new is compiled: `AddressRegistry`, which the exemplar's first released suite derives, and `MigrationRegistry`, which declares `0x6E3aE74aDCd6CF28A1b2F685D5E709ffE44D429D` — an address no released suite here derives, making it a real record file that really is undeclared, sitting LAST.

Five tests, each putting the interesting entry at a position after the first:

| test | property | mutant it uniquely kills |
| --- | --- | --- |
| `testFrozenSnapshotCheckReachesEveryRecordFile` | outer loop reaches the last file | M07, M12 |
| `testFrozenSnapshotUnreadableFileIsNamedAtEveryRecordPosition` | unreadable error names the file the loop is ON | M06 |
| `testFrozenSnapshotCheckReachesEveryReleasedSuite` | inner search reaches the last released suite | M13 |
| `testFrozenSnapshotEmptyDeclarationFailsOnTheFirstRecordFile` | not-released error names the first file when it IS the first | M08 |
| `testFrozenSnapshotEmptyRecordPasses` | an empty record passes | (see below) |

The middle-column pair matters: with a one-file record, `paths[i]`, `paths[0]` and `paths[paths.length - 1]` are indistinguishable in the revert. Naming the LAST file in one test and the FIRST in the other is what pins the index.

`testFrozenSnapshotEmptyRecordPasses` pins the deliberate asymmetry with group 2, which refuses an empty candidate list (`NoDeployCandidates`). Stated plainly: it kills no mutant that main does not already kill, because `frozenSnapshotPaths` returns zero elements while nothing is released. That incidental driver stops being empty at the first release; this test does not.

## One addition beyond the issue's proposed fix

The issue's Problem section names `testFrozenSnapshotWithoutADeployedAddressReverts` as one of the four one-file drivers, but its proposed fix does not re-drive the unreadable case. The path handed to `recordedDeployedAddress` exists solely for the `FrozenSnapshotUnreadable` error, so a mutant that keeps passing `paths[0]` while the loop advances would send a reader to a file that reads perfectly well.

That mutant is M06, and the matrix shows its ONLY killer is `testFrozenSnapshotUnreadableFileIsNamedAtEveryRecordPosition` — the test the issue's own proposal omits. Without this addition M06 stays alive. Same category the finding names, so it is recorded here rather than carried forward.

## QA
- Discriminating tests: `testFrozenSnapshotCheckReachesEveryRecordFile`, `testFrozenSnapshotUnreadableFileIsNamedAtEveryRecordPosition`, `testFrozenSnapshotCheckReachesEveryReleasedSuite`, `testFrozenSnapshotEmptyDeclarationFailsOnTheFirstRecordFile`, `testFrozenSnapshotEmptyRecordPasses` — each verified against base by re-running the SAME mutants with the test file reverted to `origin/main`: 4 of 11 mutants flip KILLED->SURVIVED (M05, M06, M07, M08), and both faithful loop-reach mutants flip 2/2 -> 0/2.
- Mutations applied: run with `mutation-probe`, which refuses a red baseline and verifies every restore byte-exact. Baselines prove the suite RAN and which test file was in place: branch scoped 27 passed, main scoped 22 passed (delta 5 = the tests added); branch whole-suite 220 passed / 0 failed, main whole-suite 215 passed.

  | mutant | line -> mutation | branch | main |
  | --- | --- | --- | --- |
  | M12 | end of outer loop body -> append `break;` | KILLED (`…ReachesEveryRecordFile`, `…UnreadableFileIsNamed…`) | **SURVIVED** |
  | M13 | end of inner loop body -> append `break;` | KILLED (`…ReachesEveryReleasedSuite`) | **SURVIVED** |
  | M05 | `vm.readFile(paths[i])` -> `vm.readFile(paths[0])` | KILLED (`…ReachesEveryRecordFile`, `…UnreadableFileIsNamed…`) | **SURVIVED** |
  | M06 | `recordedDeployedAddress(paths[i],` -> `(paths[0],` | KILLED (`…UnreadableFileIsNamed…` only) | **SURVIVED** |
  | M07 | `revert FrozenSnapshotNotReleased(paths[i])` -> `(paths[0])` | KILLED (`…ReachesEveryRecordFile` only) | **SURVIVED** |
  | M08 | same revert -> `(paths[paths.length - 1])` | KILLED (`…EmptyDeclarationFailsOnTheFirstRecordFile` only) | **SURVIVED** |
  | M03/M04 | loop start index `0` -> `1` | KILLED | KILLED (already covered) |
  | M09/M10/M11 | `declared` init, `!declared` guard, `==` -> `!=` | KILLED | KILLED (already covered) |

  Totals: branch 11/11 + 2/2 killed, 0 survived, 0 no-run, 0 harness errors; main 7/11 and 0/2 killed.

  Reported against: M01/M02 (loop bound -> `< 1`) are KILLED on main too, but by `testEveryFrozenSnapshotIsReleased` hitting an out-of-bounds index on a ZERO-length array — a kill for the wrong reason, not loop-reach coverage. M12/M13 exist because they stop the loop after one iteration while leaving the empty case identical, which is why they are the honest evidence and M01/M02 are not.
- Oracle: the issue's stated property (every file in the record is checked; the error names the file the loop is on), plus values independent of the code under test — `MigrationRegistry`'s `DEPLOYED_ADDRESS` is generated by `script/Build.sol` from creation code, and the match address is derived by `LibRainDeploy.zoltuAddress`, neither of which `checkFrozenSnapshotsReleased` participates in.
- Category check: issue asks for outer-loop reach, inner-loop reach with the `break` landing past the first suite, empty `released` against a multi-file record, and an empty record; all four covered. Added the unreadable case at a non-zero record position, which the issue's Problem section names as one of the four one-file drivers but its proposed diff leaves uncovered (M06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)