### PR TITLE
freeze: refuse a release tag that does not follow the record

### DIFF
--- a/src/lib/LibRainDeploySnapshot.sol
+++ b/src/lib/LibRainDeploySnapshot.sol
@@ -35,6 +35,16 @@ error SnapshotAlreadyFrozen(string tag, string dir);
 /// @param tag The release tag that was being cut.
 error EmptyRelease(string tag);
 
+/// Thrown when a release tag does not strictly follow every tag already frozen
+/// in the record. The record is append-only, so a tag frozen out of order can
+/// never be removed: `releasedSuites()` declares it forever and the chain group
+/// then demands it be live on every supported network forever. Refused at the
+/// one place a release identity is minted, rather than discovered afterwards by
+/// whoever reads the record and finds a release nobody cut.
+/// @param tag The tag being cut.
+/// @param newestFrozenTag The newest tag already in the record.
+error NonMonotonicRelease(string tag, string newestFrozenTag);
+
 /// @title LibRainDeploySnapshot
 /// @notice Which release is being built, where its record lives, and how it is
 /// frozen. Release machinery, not code generation.
@@ -427,30 +437,61 @@ library LibRainDeploySnapshot {
         return string.concat(contractForRecordPath(vm, path), "_", tagForRecordPath(vm, path));
     }
 
-    /// Whether record file `a` is emitted before record file `b`: by release
-    /// tag, then by path.
+    /// Whether release tag `a` strictly precedes release tag `b`.
     ///
     /// Tags compare as VERSIONS rather than as text — `0_10_0` follows `0_9_0`
     /// as a release and precedes it as a string, so a text comparison misorders
-    /// every record that outlives a single-digit minor. Both tags are `isTag`,
-    /// so every component is a run of digits `parseUint` reads.
+    /// every record that outlives a single-digit minor. Both MUST be `isTag`,
+    /// so every component is a run of digits `parseUint` reads and both have
+    /// the same number of them.
     ///
-    /// The tie break is the path, byte for byte, so two contracts frozen under
-    /// one tag have an order at all. The walk's own order is the filesystem's,
-    /// and a generated file that changes with it is a diff on every build.
+    /// The ONE definition of what "follows" means for a release, asked by the
+    /// emission order and by the freeze's ordering guard alike. Two spellings
+    /// of it is how a record sorts one way and admits a tag the other way.
+    ///
+    /// Taking the tags rather than record paths is what makes the guard
+    /// reachable: a release being cut has no record file yet, and a comparison
+    /// that could only be asked with two paths could only be asked about
+    /// releases that already happened — the same reason `tagForVersion` is
+    /// split out of `deployTag`.
     /// @param vm The Vm instance for string operations.
-    /// @param a A record file.
-    /// @param b A record file.
-    /// @return Whether `a` precedes `b`.
-    function recordPrecedes(Vm vm, string memory a, string memory b) internal pure returns (bool) {
-        string[] memory left = vm.split(tagForRecordPath(vm, a), "_");
-        string[] memory right = vm.split(tagForRecordPath(vm, b), "_");
+    /// @param a A release tag.
+    /// @param b A release tag.
+    /// @return Whether `a` strictly precedes `b`.
+    function tagPrecedes(Vm vm, string memory a, string memory b) internal pure returns (bool) {
+        string[] memory left = vm.split(a, "_");
+        string[] memory right = vm.split(b, "_");
         for (uint256 i = 0; i < left.length; i++) {
             uint256 leftComponent = vm.parseUint(left[i]);
             uint256 rightComponent = vm.parseUint(right[i]);
             if (leftComponent != rightComponent) {
                 return leftComponent < rightComponent;
             }
+        }
+        return false;
+    }
+
+    /// Whether record file `a` is emitted before record file `b`: by release
+    /// tag (`tagPrecedes`), then by path.
+    ///
+    /// The tie break is the path, byte for byte, so two contracts frozen under
+    /// one tag have an order at all. The walk's own order is the filesystem's,
+    /// and a generated file that changes with it is a diff on every build. It
+    /// applies only when neither tag precedes the other, i.e. the two files are
+    /// the same release — a tag that follows the other is ordered by that and
+    /// never by the text of its path.
+    /// @param vm The Vm instance for string operations.
+    /// @param a A record file.
+    /// @param b A record file.
+    /// @return Whether `a` precedes `b`.
+    function recordPrecedes(Vm vm, string memory a, string memory b) internal pure returns (bool) {
+        string memory leftTag = tagForRecordPath(vm, a);
+        string memory rightTag = tagForRecordPath(vm, b);
+        if (tagPrecedes(vm, leftTag, rightTag)) {
+            return true;
+        }
+        if (tagPrecedes(vm, rightTag, leftTag)) {
+            return false;
         }
 
         bytes memory aBytes = bytes(a);
@@ -711,6 +752,74 @@ library LibRainDeploySnapshot {
         return path;
     }
 
+    /// The newest release in a record: the greatest tag any of its files sits
+    /// under, compared as a version.
+    ///
+    /// The empty string when the record holds no release at all. That is a real
+    /// state — a repo before its first release, including this one — rather
+    /// than a failure, and it cannot be confused with a release because it is
+    /// not a tag `isTag` admits or a freeze could ever write.
+    ///
+    /// A scan rather than the last of `sortedRecordPaths`: the newest release
+    /// is what this is asked for, and the path tie break that orders two files
+    /// frozen under one tag has nothing to say about which tag is newest.
+    /// @param vm The Vm instance for file operations.
+    /// @param recordRoot The record root — `LIB_FS_ROOT` for a repo's real
+    /// record.
+    /// @return newest The newest frozen tag, or `""` if nothing is frozen.
+    function newestFrozenTag(Vm vm, string memory recordRoot) internal view returns (string memory newest) {
+        string[] memory paths = frozenSnapshotPaths(vm, recordRoot);
+        for (uint256 i = 0; i < paths.length; i++) {
+            string memory tag = tagForRecordPath(vm, paths[i]);
+            if (bytes(newest).length == 0 || tagPrecedes(vm, newest, tag)) {
+                newest = tag;
+            }
+        }
+    }
+
+    /// Refuse a release tag that does not strictly follow every tag already in
+    /// the record.
+    ///
+    /// The record is APPEND-ONLY, which is what makes an out-of-order tag
+    /// permanent rather than merely wrong: `releasedSuites()` is generated from
+    /// the record and declares it forever, `RainDeployVerifyChain` then demands
+    /// its addresses stay live on every supported network forever, and the
+    /// append-only gate is exactly what stops the directory being deleted. The
+    /// only exit is suspending the invariant the whole design rests on.
+    ///
+    /// Nothing upstream is a substitute. The tag is a human-typed `sol-v*` that
+    /// `rainix-tag-release` seds straight into `foundry.toml` after checking
+    /// only that it is on `main` and shaped `X.Y.Z`, so a fat-fingered `0.1.9`
+    /// cut after `0.2.0` reaches this call as the release being made.
+    /// `SnapshotAlreadyFrozen` is existence-based and has no quarrel with it —
+    /// its directory is absent precisely because that release never happened —
+    /// and the frozen bytes are the current candidate, already live on chain,
+    /// so every downstream check passes and the record simply carries a release
+    /// sorted below the newest one.
+    ///
+    /// Strictly greater, so the newest tag itself is refused too: equality is
+    /// not "follows". `SnapshotAlreadyFrozen` also refuses that one, and both
+    /// must hold — neither guard is load bearing alone.
+    ///
+    /// The record root and the tag are parameters, so the refusal is reachable
+    /// without a record on disk to re-cut or a `foundry.toml` to rewrite, for
+    /// the same reason `frozenSnapshotPaths` takes a root and `tagForVersion`
+    /// is split out of `deployTag`. A guard nobody has seen fire is a guard
+    /// nobody knows works, which is the whole complaint against an unenforced
+    /// rule.
+    /// @param vm The Vm instance for file operations.
+    /// @param recordRoot The record root — `LIB_FS_ROOT` for a repo's real
+    /// record.
+    /// @param tag The release tag being cut. MUST be `isTag`.
+    function checkReleaseFollowsRecord(Vm vm, string memory recordRoot, string memory tag) internal view {
+        string memory newest = newestFrozenTag(vm, recordRoot);
+        // A repo that has released nothing has nothing for a first release to
+        // follow, so there is no tag it may not be.
+        if (bytes(newest).length > 0 && !tagPrecedes(vm, newest, tag)) {
+            revert NonMonotonicRelease(tag, newest);
+        }
+    }
+
     /// Regenerate the rolling snapshot and freeze it as this release's record,
     /// in that order, in one call.
     ///
@@ -730,6 +839,9 @@ library LibRainDeploySnapshot {
     /// - the release must name at least one contract, because a release with no
     ///   record is not a release and freezing one wedges the tag exactly as a
     ///   partial write does
+    /// - the tag must strictly follow every release already frozen
+    ///   (`checkReleaseFollowsRecord`), because the record it is appended to
+    ///   cannot be reordered or removed afterwards
     /// - every named contract must have a rolling snapshot, once regenerated
     ///
     /// The frozen copy is the bytes just regenerated, read back from disk, so
@@ -748,6 +860,11 @@ library LibRainDeploySnapshot {
         if (contractNames.length == 0) {
             revert EmptyRelease(tag);
         }
+        // The record this release is appended to is the one it is written into,
+        // so the root is `LIB_FS_ROOT` and not a caller's choice: a guard that
+        // could be pointed at another tree is a guard that could be pointed
+        // away from the record it is protecting.
+        checkReleaseFollowsRecord(vm, LIB_FS_ROOT, tag);
 
         regenerate();
 

--- a/test/fixture-record/1_1_1/MockDeployable.txt
+++ b/test/fixture-record/1_1_1/MockDeployable.txt
@@ -1,0 +1,13 @@
+SPDX-License-Identifier: LicenseRef-DCL-1.0
+SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+
+A record fixture holding exactly one release, `1_1_1`, for the freeze's
+ordering guard to be fuzzed against. Committed rather than written by the test
+that reads it: forge runs the cases of a fuzz test CONCURRENTLY, so a fixture a
+fuzz builds and tears down races itself — one case removes the record another
+case is reading. A record that is simply there is the only kind a fuzz can be
+put against.
+
+Deliberately not `.sol`. A release directory holds every file in it and there is
+no extension to filter on, so the record walk finds this exactly as it finds a
+real snapshot, while the compiler never reads a fixture as source.

--- a/test/src/lib/LibRainDeploySnapshot.t.sol
+++ b/test/src/lib/LibRainDeploySnapshot.t.sol
@@ -8,6 +8,7 @@ import {DeploySuite} from "../../../src/abstract/RainDeploySuitesBase.sol";
 import {
     EmptyRelease,
     LibRainDeploySnapshot,
+    NonMonotonicRelease,
     NothingToFreeze,
     UnreleasableVersion
 } from "../../../src/lib/LibRainDeploySnapshot.sol";
@@ -37,6 +38,26 @@ contract LibRainDeploySnapshotTest is Test {
     /// @param contractNames The contracts to freeze.
     function externalFreeze(string[] memory contractNames) external {
         LibRainDeploySnapshot.freeze(vm, noRegeneration, contractNames);
+    }
+
+    /// External wrapper so `vm.expectRevert` lands at the right call depth. The
+    /// accepting cases go through it too, so both answers are the same call.
+    /// @param recordRoot The record root to check against.
+    /// @param tag The release tag being cut.
+    function externalCheckReleaseFollowsRecord(string memory recordRoot, string memory tag) external view {
+        LibRainDeploySnapshot.checkReleaseFollowsRecord(vm, recordRoot, tag);
+    }
+
+    /// A release tag from its components, as `tagForVersion` spells one.
+    /// @param major The major component.
+    /// @param minor The minor component.
+    /// @param patch The patch component.
+    /// @return The tag, e.g. `0_1_7`.
+    function tagOf(uint8 major, uint8 minor, uint8 patch) internal pure returns (string memory) {
+        return
+            string.concat(
+                vm.toString(uint256(major)), "_", vm.toString(uint256(minor)), "_", vm.toString(uint256(patch))
+            );
     }
 
     /// Where the record fixture is built. NOT `src/generated`: the inherited
@@ -470,6 +491,61 @@ contract LibRainDeploySnapshotTest is Test {
         );
     }
 
+    /// Tags MUST compare as VERSIONS and not as text. `0_10_0` follows `0_9_0`
+    /// as a release and precedes it as a string, so a text comparison both
+    /// misorders the record and, since the freeze's ordering guard asks this
+    /// same question, would admit a release below the newest one.
+    ///
+    /// Strictly: a tag does not precede itself. That is the boundary the guard
+    /// refuses on, so "follows" meaning "greater or equal" here would be a tag
+    /// re-cut being called a new release.
+    function testTagPrecedesComparesVersionsNotText() external pure {
+        assertTrue(LibRainDeploySnapshot.tagPrecedes(vm, "0_9_0", "0_10_0"));
+        assertFalse(LibRainDeploySnapshot.tagPrecedes(vm, "0_10_0", "0_9_0"));
+
+        assertFalse(LibRainDeploySnapshot.tagPrecedes(vm, "0_1_7", "0_1_7"));
+
+        // Every component, and the most significant one that differs decides.
+        assertTrue(LibRainDeploySnapshot.tagPrecedes(vm, "0_1_6", "0_1_7"));
+        assertFalse(LibRainDeploySnapshot.tagPrecedes(vm, "0_1_7", "0_1_6"));
+        assertTrue(LibRainDeploySnapshot.tagPrecedes(vm, "0_1_9", "0_2_0"));
+        assertFalse(LibRainDeploySnapshot.tagPrecedes(vm, "0_2_0", "0_1_9"));
+        assertTrue(LibRainDeploySnapshot.tagPrecedes(vm, "0_9_9", "1_0_0"));
+        assertFalse(LibRainDeploySnapshot.tagPrecedes(vm, "1_0_0", "0_9_9"));
+    }
+
+    /// Over EVERY pair of tags, the order MUST be the order of the components
+    /// read as numbers, most significant first — a single wrong comparison is a
+    /// record that sorts wrongly and a guard that admits the tag it sorts
+    /// wrongly.
+    /// @param aMajor The first tag's major component.
+    /// @param aMinor The first tag's minor component.
+    /// @param aPatch The first tag's patch component.
+    /// @param bMajor The second tag's major component.
+    /// @param bMinor The second tag's minor component.
+    /// @param bPatch The second tag's patch component.
+    function testTagPrecedesMatchesComponentOrder(
+        uint8 aMajor,
+        uint8 aMinor,
+        uint8 aPatch,
+        uint8 bMajor,
+        uint8 bMinor,
+        uint8 bPatch
+    ) external pure {
+        string memory a = tagOf(aMajor, aMinor, aPatch);
+        string memory b = tagOf(bMajor, bMinor, bPatch);
+
+        bool precedes = aMajor != bMajor
+            ? aMajor < bMajor
+            : (aMinor != bMinor ? aMinor < bMinor : (aPatch != bPatch ? aPatch < bPatch : false));
+
+        assertEq(LibRainDeploySnapshot.tagPrecedes(vm, a, b), precedes);
+        // Strict, so exactly one of the two orderings holds unless they are the
+        // same release, when neither does.
+        assertFalse(LibRainDeploySnapshot.tagPrecedes(vm, a, a));
+        assertEq(LibRainDeploySnapshot.tagPrecedes(vm, b, a), !precedes && keccak256(bytes(a)) != keccak256(bytes(b)));
+    }
+
     /// Releases MUST be emitted in the order they were cut, comparing tags as
     /// VERSIONS. `0_10_0` follows `0_9_0` as a release and precedes it as text,
     /// so a sort on the raw string misorders every record that outlives a
@@ -671,5 +747,170 @@ contract LibRainDeploySnapshotTest is Test {
         this.externalFreeze(contractNames);
 
         assertFalse(vm.exists(LibRainDeploySnapshot.dirForSnapshot(tag)));
+    }
+
+    /// Every record the ordering guard is driven against gets a root of its
+    /// own, for the reason `RELEASED_FIXTURE_ROOT` is not `FIXTURE_ROOT`: forge
+    /// runs the tests in a contract concurrently, and a guard test sees the
+    /// wrong newest release the moment another test's fixture is in the tree it
+    /// is reading.
+    string constant NEWEST_FIXTURE_ROOT = "test/generated-newest";
+
+    /// The record with nothing released in it. See `NEWEST_FIXTURE_ROOT`.
+    string constant UNRELEASED_FIXTURE_ROOT = "test/generated-unreleased";
+
+    /// The record a below-the-newest tag is refused against. See
+    /// `NEWEST_FIXTURE_ROOT`.
+    string constant BELOW_FIXTURE_ROOT = "test/generated-below";
+
+    /// The record the newest tag itself is refused against. See
+    /// `NEWEST_FIXTURE_ROOT`.
+    string constant EQUAL_FIXTURE_ROOT = "test/generated-equal";
+
+    /// The record strictly greater tags are accepted against. See
+    /// `NEWEST_FIXTURE_ROOT`.
+    string constant GREATER_FIXTURE_ROOT = "test/generated-greater";
+
+    /// The record every fuzzed tag is put to. COMMITTED, and read only — see
+    /// the fixture itself for why a fuzz cannot build the record it is put
+    /// against.
+    string constant FROZEN_FIXTURE_ROOT = "test/fixture-record";
+
+    /// The one release in `FROZEN_FIXTURE_ROOT`. Every component is the same,
+    /// so a fuzzed tag that differs in any one of them lands on one side of it
+    /// or the other by that component alone.
+    string constant FROZEN_FIXTURE_NEWEST = "1_1_1";
+
+    /// The newest release is the greatest TAG, not a position in the walk. The
+    /// walk's order is the filesystem's, so an answer read off either end of it
+    /// is an answer about where a directory sorted rather than which release is
+    /// newest — and the guard would then compare the tag being cut against the
+    /// wrong release.
+    ///
+    /// `10_0_0` is the newest of these three and is neither the first nor the
+    /// last of them by text, so both ends are wrong answers here.
+    function testNewestFrozenTagIsTheGreatestReleaseNotAPositionInTheWalk() external {
+        writeFixture(string.concat(NEWEST_FIXTURE_ROOT, "/0_1_0/", FIXTURE_CONTRACT, ".sol"));
+        writeFixture(string.concat(NEWEST_FIXTURE_ROOT, "/10_0_0/", FIXTURE_CONTRACT, ".sol"));
+        writeFixture(string.concat(NEWEST_FIXTURE_ROOT, "/9_0_0/", FIXTURE_CONTRACT, ".sol"));
+        // Not releases: the rolling snapshot, and a scratch directory a test or
+        // a human left behind. Neither is a release the next one has to follow.
+        writeFixture(
+            string.concat(NEWEST_FIXTURE_ROOT, "/", LibRainDeploySnapshot.CANDIDATE, "/", FIXTURE_CONTRACT, ".sol")
+        );
+        writeFixture(string.concat(NEWEST_FIXTURE_ROOT, "/collision-guard/", FIXTURE_CONTRACT, ".sol"));
+
+        string memory newest = LibRainDeploySnapshot.newestFrozenTag(vm, NEWEST_FIXTURE_ROOT);
+
+        //forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.removeDir(NEWEST_FIXTURE_ROOT, true);
+
+        assertEq(newest, "10_0_0");
+    }
+
+    /// A repo that has released nothing has nothing for a first release to
+    /// follow, so EVERY tag MUST be accepted. That is the state of this repo
+    /// today, so a guard that refused here would refuse the first release of
+    /// every deploy repo that inherits it.
+    ///
+    /// Both spellings of "nothing released": a record root that is not there at
+    /// all, and one that is there holding only a rolling snapshot.
+    function testNoFrozenReleaseAcceptsAnyFirstRelease() external {
+        assertEq(LibRainDeploySnapshot.newestFrozenTag(vm, MISSING_FIXTURE_ROOT), "");
+        this.externalCheckReleaseFollowsRecord(MISSING_FIXTURE_ROOT, "0_0_1");
+        this.externalCheckReleaseFollowsRecord(MISSING_FIXTURE_ROOT, "9_9_9");
+
+        writeFixture(
+            string.concat(UNRELEASED_FIXTURE_ROOT, "/", LibRainDeploySnapshot.CANDIDATE, "/", FIXTURE_CONTRACT, ".sol")
+        );
+
+        string memory newest = LibRainDeploySnapshot.newestFrozenTag(vm, UNRELEASED_FIXTURE_ROOT);
+        this.externalCheckReleaseFollowsRecord(UNRELEASED_FIXTURE_ROOT, "0_0_1");
+
+        //forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.removeDir(UNRELEASED_FIXTURE_ROOT, true);
+
+        assertEq(newest, "");
+    }
+
+    /// A tag BELOW the newest release MUST be refused, and against the NEWEST
+    /// release rather than any release. The record is append-only, so a tag
+    /// frozen out of order is permanent: `releasedSuites()` declares it forever
+    /// and the chain group then demands it stay live forever.
+    ///
+    /// This is the production shape. `0_1_9` is a plausible fat finger for the
+    /// release after `0_2_0`, it is greater than a release that IS in the
+    /// record, and every other guard admits it — its directory does not exist,
+    /// its shape is a valid version, and the bytes it would freeze are the
+    /// candidate's, already live on chain.
+    function testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease() external {
+        writeFixture(string.concat(BELOW_FIXTURE_ROOT, "/0_1_0/", FIXTURE_CONTRACT, ".sol"));
+        writeFixture(string.concat(BELOW_FIXTURE_ROOT, "/0_2_0/", FIXTURE_CONTRACT, ".sol"));
+
+        vm.expectRevert(abi.encodeWithSelector(NonMonotonicRelease.selector, "0_1_9", "0_2_0"));
+        this.externalCheckReleaseFollowsRecord(BELOW_FIXTURE_ROOT, "0_1_9");
+
+        //forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.removeDir(BELOW_FIXTURE_ROOT, true);
+    }
+
+    /// The newest tag ITSELF MUST be refused: equality is not "follows". The
+    /// fail-safe boundary, and the one case `SnapshotAlreadyFrozen` also
+    /// refuses — both must hold, so neither is load bearing alone and this one
+    /// holds against a record root whose directories are not where a freeze
+    /// would look for them.
+    function testCheckReleaseFollowsRecordRefusesTheNewestTagItself() external {
+        writeFixture(string.concat(EQUAL_FIXTURE_ROOT, "/0_2_0/", FIXTURE_CONTRACT, ".sol"));
+
+        vm.expectRevert(abi.encodeWithSelector(NonMonotonicRelease.selector, "0_2_0", "0_2_0"));
+        this.externalCheckReleaseFollowsRecord(EQUAL_FIXTURE_ROOT, "0_2_0");
+
+        //forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.removeDir(EQUAL_FIXTURE_ROOT, true);
+    }
+
+    /// A tag that strictly follows the newest release MUST be accepted,
+    /// whichever component moved — a guard that refused an ordinary release
+    /// would stop every release this repo cuts.
+    ///
+    /// The last pair is the one a text comparison gets wrong: `0_10_0` follows
+    /// `0_9_0` as a release and precedes it as a string.
+    function testCheckReleaseFollowsRecordAcceptsAnyStrictlyGreaterTag() external {
+        string[3] memory records = ["0_1_6", "0_9_9", "0_9_0"];
+        string[3] memory tags = ["0_1_7", "1_0_0", "0_10_0"];
+
+        for (uint256 i = 0; i < records.length; i++) {
+            writeFixture(string.concat(GREATER_FIXTURE_ROOT, "/", records[i], "/", FIXTURE_CONTRACT, ".sol"));
+
+            this.externalCheckReleaseFollowsRecord(GREATER_FIXTURE_ROOT, tags[i]);
+
+            //forge-lint: disable-next-line(unsafe-cheatcode)
+            vm.removeDir(GREATER_FIXTURE_ROOT, true);
+        }
+    }
+
+    /// Over EVERY tag, against a record on disk, the guard MUST accept exactly
+    /// the tags that strictly follow the newest release and refuse every other
+    /// one, naming both tags when it does.
+    ///
+    /// The record is asserted to be the fixture on every case rather than
+    /// assumed: the whole answer is relative to the newest release, so a
+    /// fixture that has quietly grown a release is a test that has quietly
+    /// changed what it asks.
+    /// @param major The candidate tag's major component.
+    /// @param minor The candidate tag's minor component.
+    /// @param patch The candidate tag's patch component.
+    function testCheckReleaseFollowsRecordAcceptsExactlyTheStrictlyGreater(uint8 major, uint8 minor, uint8 patch)
+        external
+    {
+        assertEq(LibRainDeploySnapshot.newestFrozenTag(vm, FROZEN_FIXTURE_ROOT), FROZEN_FIXTURE_NEWEST);
+
+        string memory tag = tagOf(major, minor, patch);
+        bool follows = major != 1 ? major > 1 : (minor != 1 ? minor > 1 : patch > 1);
+
+        if (!follows) {
+            vm.expectRevert(abi.encodeWithSelector(NonMonotonicRelease.selector, tag, FROZEN_FIXTURE_NEWEST));
+        }
+        this.externalCheckReleaseFollowsRecord(FROZEN_FIXTURE_ROOT, tag);
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/84.

## The gap

`freeze` ran three guards — the version is a strict `X.Y.Z`, the tag is not already frozen, the release names at least one contract — and not one of them is about ORDER. So a `sol-v0.1.9` cut after `0.2.0` passes every one of them: its directory is absent precisely because that release never happened, and the bytes it freezes are the current candidate's, already live on every chain, so the pre-publish chain gate is green too.

The record is APPEND-ONLY, which is what turns that from wrong into permanent. `releasedSuites()` is generated from the record and declares the phantom release forever, `RainDeployVerifyChain` then demands its addresses stay live on every supported network forever, and the `frozen-snapshots-append-only` gate is exactly what stops the directory being deleted. The only exit is suspending the invariant the whole design rests on.

The ordering predicate was already in the library. `recordPrecedes` compares tags numerically per component precisely because `0_10_0` follows `0_9_0` as a release and precedes it as a string — `freeze` just never asked it.

## The change

`src/lib/LibRainDeploySnapshot.sol`:

- **`tagPrecedes(vm, a, b)`** — the numeric per-component comparison, split out of `recordPrecedes` behaviour-preservingly. `recordPrecedes` now asks `tagPrecedes` in both directions and falls through to its byte-for-byte path tie break only when neither tag precedes the other, i.e. the two files are the same release. One definition of "follows" answers the emission order and the guard alike; two spellings of it is how a record sorts one way and admits a tag the other way.
- **`newestFrozenTag(vm, recordRoot)`** — the greatest tag any file in a record sits under, compared as a version. `""` when nothing is frozen, which is a real state (every deploy repo before its first release, including this one) rather than a failure, and cannot collide with a release because it is not a tag `isTag` admits or a freeze could write. A scan, not the last of `sortedRecordPaths`: the path tie break that orders two contracts frozen under one tag has nothing to say about which tag is newest.
- **`checkReleaseFollowsRecord(vm, recordRoot, tag)`** — reverts `NonMonotonicRelease(tag, newestFrozenTag)` unless the tag strictly follows the newest release. Strictly, so the newest tag itself is refused: equality is not "follows". `SnapshotAlreadyFrozen` also refuses that one, and both must hold, so neither guard is load bearing alone.
- **`freeze`** calls it before `regenerate()`, alongside the existing guards.

## Design decisions

**The record root and the tag are parameters on the GUARD, not on `freeze`.** `freeze` passes `LIB_FS_ROOT` unconditionally. A caller-chosen read root on `freeze` would be a silent guard-disable with no backstop, because `freeze` writes into `LIB_FS_ROOT` regardless — the guard could be pointed away from the record it is protecting while the write still lands in it. Parameterising the guard is what makes the refusal reachable at all: the issue's own verification pass flagged that `freeze` reads the real `foundry.toml` (read-only under `fs_permissions`) and would read the real `LIB_FS_ROOT`, so a guard hung only off `freeze` would be as unexercisable as the unenforced rule it replaces. Same reason `frozenSnapshotPaths` takes a root and `tagForVersion` is split out of `deployTag`.

**The fuzzed guard test reads a committed `.txt` fixture.** forge 1.7.2-nightly runs the cases of a fuzz test CONCURRENTLY, so a test that builds and tears down its own filesystem fixture races itself — one case removes the record another case is reading. A record that is simply there is the only kind a fuzz can be put against. `.txt` is deliberate, not an oversight: a release directory holds every file in it and the record walk has no extension filter, so the walk finds this exactly as it finds a real snapshot, while the compiler never reads a fixture as source. The reasoning is in the fixture file itself.

Every non-fuzzed guard test still gets a record root of its own, for the reason `RELEASED_FIXTURE_ROOT` is not `FIXTURE_ROOT`: forge runs the tests in a contract concurrently, and a guard test sees the wrong newest release the moment another test's fixture is in the tree it is reading.

**`tagPrecedes` is a behaviour-preserving split.** No caller of `recordPrecedes` changes answer.

**README and CLAUDE.md are untouched.** Neither documents the freeze guard list.

## Tests

`test/src/lib/LibRainDeploySnapshot.t.sol`, all driven through an external wrapper so `vm.expectRevert` lands at the right call depth — the accepting cases go through it too, so both answers come from the same call.

- `testTagPrecedesComparesVersionsNotText` — `0_9_0` < `0_10_0` and not the reverse; every component, most significant difference deciding; and strictly, a tag does not precede itself.
- `testTagPrecedesMatchesComponentOrder` (fuzz) — over every pair of tags, the order is the order of the components read as numbers; exactly one of the two orderings holds unless they are the same release, when neither does.
- `testNewestFrozenTagIsTheGreatestReleaseNotAPositionInTheWalk` — `10_0_0` among `0_1_0`/`9_0_0` is neither the first nor the last by text, so an answer read off either end of the walk is wrong. The rolling candidate and a leftover scratch directory are in the tree and are not releases.
- `testNoFrozenReleaseAcceptsAnyFirstRelease` — both spellings of nothing released (root absent, root holding only the candidate) accept any first release. A guard that refused here would refuse the first release of every deploy repo that inherits it.
- `testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease` — the production shape: `0_1_9` against a record holding `0_1_0` and `0_2_0`. Greater than a release that IS in the record, and refused against the NEWEST one.
- `testCheckReleaseFollowsRecordRefusesTheNewestTagItself` — the fail-safe boundary.
- `testCheckReleaseFollowsRecordAcceptsAnyStrictlyGreaterTag` — patch, major, and the `0_9_0` → `0_10_0` pair a text comparison gets wrong.
- `testCheckReleaseFollowsRecordAcceptsExactlyTheStrictlyGreater` (fuzz) — over every tag, against the committed record, accepts exactly the strictly greater and refuses every other one, naming both tags. Re-asserts the fixture's newest release on every case rather than assuming it: the whole answer is relative to the newest release, so a fixture that had quietly grown one would be a test that had quietly changed what it asks.

## QA

- **Discriminating tests:** `testTagPrecedesComparesVersionsNotText`, `testTagPrecedesMatchesComponentOrder` (fuzz), `testNewestFrozenTagIsTheGreatestReleaseNotAPositionInTheWalk`, `testNoFrozenReleaseAcceptsAnyFirstRelease`, `testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease`, `testCheckReleaseFollowsRecordRefusesTheNewestTagItself`, `testCheckReleaseFollowsRecordAcceptsAnyStrictlyGreaterTag`, `testCheckReleaseFollowsRecordAcceptsExactlyTheStrictlyGreater` (fuzz) — each fails on base, in the strongest form: `tagPrecedes`, `newestFrozenTag` and `checkReleaseFollowsRecord` do not exist before this diff, so the suite does not compile against it. Per-behaviour discrimination is therefore the mutation matrix below, run against the landed code, which is the evidence that each test kills the specific line it claims.
- **Mutations applied** (`mutation-probe`, baseline green at 159 tests / 0 failed / 14 suites, 9 of 10 killed):

  | # | line → mutation | verdict / killing test |
  |---|---|---|
  | M01 | `LibRainDeploySnapshot.sol:468` `return leftComponent < rightComponent` → `>` | KILLED — `testTagPrecedesComparesVersionsNotText`, `testSortedRecordPathsOrdersTagsAsVersions`, `testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease`, +2 |
  | M02 | `:464` `i < left.length` → `i < 1` (most significant component only) | KILLED — `testTagPrecedesComparesVersionsNotText`, `testCheckReleaseFollowsRecordAcceptsAnyStrictlyGreaterTag`, +3 |
  | M03 | `:471` `return false` → `return true` (a tag precedes itself) | KILLED — `testCheckReleaseFollowsRecordRefusesTheNewestTagItself`, `testTagPrecedesComparesVersionsNotText`, `testSortedRecordPathsOrdersTagsAsVersions` |
  | M04 | `:490-492` tag-order branch `return true` → `return false` (falls through to the path tie break) | KILLED — `testSortedRecordPathsOrdersTagsAsVersions`, `testRecordPathsForContractSelectsOneContractInTagOrder` |
  | M05 | `:493-495` reverse tag-order branch `return false` → `return true` | KILLED — `testSortedRecordPathsOrdersTagsAsVersions` |
  | M06 | `:774` drop `\|\| tagPrecedes(...)` (first release in the walk, not the greatest) | KILLED — `testNewestFrozenTagIsTheGreatestReleaseNotAPositionInTheWalk`, `testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease` |
  | M07 | `:774` `tagPrecedes(vm, newest, tag)` → `tagPrecedes(vm, tag, newest)` (oldest release) | KILLED — `testNewestFrozenTagIsTheGreatestReleaseNotAPositionInTheWalk`, `testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease` |
  | M08 | `:818` drop the `!` (accepts exactly the tags it should refuse) | KILLED — `testCheckReleaseFollowsRecordRefusesATagBelowTheNewestRelease`, `testCheckReleaseFollowsRecordRefusesTheNewestTagItself`, `testCheckReleaseFollowsRecordAcceptsAnyStrictlyGreaterTag` |
  | M09 | `:818` drop `bytes(newest).length > 0 &&` (refuses every first release) | KILLED — `testNoFrozenReleaseAcceptsAnyFirstRelease`, `testFreezeLeavesNothingBehindWhenThereIsNothingToFreeze` |
  | M10 | `:867` comment out `checkReleaseFollowsRecord(vm, LIB_FS_ROOT, tag)` in `freeze` | **SURVIVED** |

  **M10 survived and is not papered over.** It is `freeze`'s CALL to the guard, and it is structural, not a missing test. `freeze` takes its two inputs from the environment and neither can be moved by a test: the tag comes from `[package].version`, which `fs_permissions` grants `read` only, and the record root is `LIB_FS_ROOT`, which no test may put a release into because contracts forge runs in parallel walk that same root (the reason the fixtures live under `test/`, stated in `foundry.toml`). Both ends of that are checkable: `src/generated/` today holds only `candidate`, so `newestFrozenTag` returns `""` and the guard is a correct no-op — removing the call is unobservable. And once a release does exist, `[package].version` and the newest frozen tag move in lockstep, so `deployTag` equals the newest tag and `SnapshotAlreadyFrozen` (line 858) fires ahead of the guard (line 867) anyway. Killing M10 would take either a writable version input or a fixture release inside the real record, and the second is exactly the thing that breaks the parallel suites. The guard's own behaviour is fully covered by M06-M09; what is unproven by test is only that `freeze` is wired to it, which the diff shows directly.

  Three fork suites (`RainDeployVerifyChainTest`, `RainDeployVerifyChainCandidateTest`, `LibRainDeployTest`) were excluded from the probe run: they need `<NETWORK>_RPC_URL`, which CI's rpc-preflight binds and the probe host has not got. None of the three references `LibRainDeploySnapshot`, so none could have killed a mutant in it. CI runs them.
- **Oracle:** the ordering rule as #84 states it and ordinary semver precedence, derived in the test independently of the implementation. Both fuzz tests compute the expected answer from the raw `uint8` components by comparison (`aMajor != bMajor ? aMajor < bMajor : ...`), never by calling the code under test, so the assertion differs from the implementation's own answer whenever the implementation is wrong. The revert oracle is the exact `NonMonotonicRelease(tag, newest)` payload, both arguments asserted, not just the selector.
- **Category check:** #84 asks for (a) the tag comparison extracted so `freeze` can use it, (b) a guard refusing any tag not strictly following the record, (c) numeric-not-lexicographic ordering, (d) equality refused, (e) the first release accepted on an empty record, (f) strictly-greater accepted, (g) a fuzzed case. Covered: (a) `tagPrecedes`, (b) `checkReleaseFollowsRecord` called from `freeze`, (c) `testTagPrecedesComparesVersionsNotText` + `testTagPrecedesMatchesComponentOrder`, (d) `testCheckReleaseFollowsRecordRefusesTheNewestTagItself`, (e) `testNoFrozenReleaseAcceptsAnyFirstRelease`, (f) `testCheckReleaseFollowsRecordAcceptsAnyStrictlyGreaterTag`, (g) both fuzz tests. The issue spells its example tests against `freeze` itself; they are landed against the guard instead, which is what the issue's own verification section concludes is required — it flags that `freeze` reads the real read-only `foundry.toml` and the real `LIB_FS_ROOT`, so a guard reachable only through `freeze` "will be as unexercisable as the finding says an unenforced rule is". The issue's `testFreezeLeavesNothingBehindOnANonMonotonicTag` is the one example with no direct equivalent, for the same reason M10 survives; the property it wants is held structurally, by the guard sitting ahead of `regenerate()` and every write.
