### PR TITLE
docs: name every RegistryDeploySuites inheritor, without a count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ purpose: the suites and the broadcast are both inherited. Run only via the
 
 **`src/abstract/RegistryDeploySuites.sol`** — this repo's own declaration, one
 named candidate per deployed registry, inherited by `script/Deploy.sol`,
-`script/Build.sol` and both pins test contracts.
+`script/Build.sol`, the pins test contracts and `GeneratedSnapshotShapeTest`.
 
 **`src/abstract/RainDeployVerify*.sol`** — the deploy-pin verification every
 deploy repo inherits instead of hand-writing.

--- a/src/abstract/RegistryDeploySuites.sol
+++ b/src/abstract/RegistryDeploySuites.sol
@@ -21,15 +21,21 @@ import {LibMigrationRegistryReleased} from "../lib/LibMigrationRegistryReleased.
 /// @title RegistryDeploySuites
 /// @notice Everything this repo deploys, declared ONCE.
 ///
-/// Three contracts inherit this and nothing else declares a suite:
+/// These contracts inherit it, and nothing else declares a suite:
 ///
 /// - `script/Deploy.sol` broadcasts from it
+/// - `script/Build.sol` generates the snapshots, the alias libs and the
+///   released-suites libs from it — the named candidates below are the
+///   templates it emits from, which is why it inherits the declaration rather
+///   than restating the key, the artifact path and the dependency list
 /// - `RegistryDeploySnapshotTest` checks its records against its creation code
 /// - `RegistryDeployChainTest` checks it against every chain
+/// - `GeneratedSnapshotShapeTest` checks the shape of the files that generation
+///   writes
 ///
 /// So "the deploy script broadcasts one contract while the tests verify
 /// another" is not a thing that can be true here. Not because something checks
-/// for it — because there is only one list, and all three read it.
+/// for it — because there is only one list, and they all read it.
 ///
 /// It lives in `src/` rather than `test/` for two reasons. `.soldeerignore`
 /// excludes `test/`, and a downstream `script/` has to import its own


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/55 (audit finding `ABS-07`, dimension 4, severity LOW).

## The defect

`src/abstract/RegistryDeploySuites.sol` opened with "Three contracts inherit this and nothing else declares a suite" and closed "there is only one list, and all three read it". Five contracts inherit it:

- `script/Deploy.sol:36`
- `script/Build.sol:79`
- `test/src/abstract/RegistryDeploySnapshot.t.sol:24`
- `test/src/abstract/RegistryDeployChain.t.sol:29`
- `test/src/lib/GeneratedSnapshotShape.t.sol:37`

The omissions are the two that make the file's own argument. `script/Build.sol:65-68` states it inherits the declaration precisely so the suite key, artifact path and dependency list are spelled once — "a second copy of them here is a second copy that drifts" — and it is what emits the `releasedSuites()` this same file returns. A reader taking the docstring at its word concludes the generator restates the declaration, which inverts the single-source property the file exists to argue for. The header contradicted itself lower down too: it already said the released libs "come from `script/Build.sol`", and `addressRegistryCandidate`'s docstring already said "Build.sol inherits this rather than restating them".

## The fix

The issue's proposed diff corrected the cardinal to five. Per the ruling in the issue's verification block, the leading cardinal is itself the fragile part, so this drops it rather than re-pins it: a count is a claim a sixth inheritor falsifies silently, and nothing enforces it. The readers are named, the opening reads "These contracts inherit it, and nothing else declares a suite", and the close reads "they all read it".

`CLAUDE.md:300-302` described the same fact and disagreed with both the old docstring and the code, listing four inheritors and omitting `GeneratedSnapshotShapeTest`. It now names the same set, also without a count ("both pins test contracts" → "the pins test contracts", for the same reason).

## QA
- Discriminating tests: n/a — the diff is comment-only, in two files that emit no bytecode behaviour. There is no runtime behaviour to discriminate on, and no test in the repo asserts on docstring prose (grep of `test/` finds nothing reading these comments). Adding a test that pins the comment text would enshrine the enumeration this change exists to de-fragilise.
- Mutations applied: n/a — a comment-only diff has no executable lines to mutate. Compilation before and after produces identical bytecode.
- Oracle: `grep -rn RegistryDeploySuites --include=*.sol .` run against this branch — the compiler's own inheritance graph, derived independently of the issue text and of the prose being corrected. It returns exactly the five inheritors now named, and the docstring is checked against that grep rather than against the issue's proposed diff.
- Category check: the issue asks for (a) the docstring's inheritor list corrected, and (b) CLAUDE.md's matching sentence corrected so the two agree. Both covered. The issue's verification block additionally rules that the durable form names the readers without a leading cardinal — applied to the opening line, the closing "all three", and to CLAUDE.md's "both pins test contracts", so no count survives anywhere in either description.

## Verification

- `forge fmt --check` — passes
- `forge build` — succeeds; the only output is warnings already present on `main` (`GeneratedSnapshotShape.t.sol:126` mutability, `LibRainDeploy.sol:304` unsafe-typecast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
