### PR TITLE
docs: place consumer example verification tests by subject path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ abstract contract MyDeploySuites is RainDeploySuitesBase {
 // script/Deploy.sol
 contract Deploy is MyDeploySuites, RainDeployBroadcast {}
 
-// test/src/concrete/MyDeploySnapshot.t.sol
+// test/src/abstract/MyDeploySnapshot.t.sol
 contract MyDeploySnapshotTest is MyDeploySuites, RainDeployVerifySnapshot {}
 
-// test/src/concrete/MyDeployChain.t.sol
+// test/src/abstract/MyDeployChain.t.sol
 contract MyDeployChainTest is MyDeploySuites, RainDeployVerifyChain {}
 ```
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/66 (audit finding `D3-03`).

## The defect

`README.md:64,67` — the "One declaration, deployed and verified" example told a consumer to write its two verification contracts at `test/src/concrete/MyDeploySnapshot.t.sol` and `test/src/concrete/MyDeployChain.t.sol`.

`test/src/**` mirrors `src/**` by SUBJECT. The subject of both contracts is the example's own `src/abstract/MyDeploySuites.sol`, declared nine lines earlier in the same code block. The example declares no `src/concrete/MyDeploySnapshot.sol` or `src/concrete/MyDeployChain.sol`, so those mirror paths corresponded to nothing.

This repo does the identical construct the other way in its own tree — `test/src/abstract/RegistryDeploySnapshot.t.sol` and `test/src/abstract/RegistryDeployChain.t.sol`, both placed by their subject `src/abstract/RegistryDeploySuites.sol` rather than by `src/concrete/AddressRegistry.sol` / `src/concrete/MigrationRegistry.sol` whose pins they actually assert. So the README taught every downstream deploy repo a placement this repo itself rejects for the same pair of contracts.

`CLAUDE.md:261-270` states the rule and reserves `test/src/concrete/` for the ordinary deployed contracts in `src/concrete/`.

## The diff

Two path strings, one comment each:

```diff
-// test/src/concrete/MyDeploySnapshot.t.sol
+// test/src/abstract/MyDeploySnapshot.t.sol
 contract MyDeploySnapshotTest is MyDeploySuites, RainDeployVerifySnapshot {}

-// test/src/concrete/MyDeployChain.t.sol
+// test/src/abstract/MyDeployChain.t.sol
 contract MyDeployChainTest is MyDeploySuites, RainDeployVerifyChain {}
```

## QA

- Discriminating tests: n/a — nothing compiles, imports or reads `README.md`. A comment inside a fenced solidity block naming a path that does not exist in this repo is unreachable from any Solidity, script or config file, so there is no artifact a test could assert against. `REUSE.toml:10` is the only file in the repo that names `README.md` at all, and it names it by a path this diff does not touch.
- Mutations applied: n/a — a docs-only diff has no executable line to mutate. Reverting either changed line to `test/src/concrete/` leaves the whole suite green, which is precisely the finding: the README is uncovered by construction, not by omission.
- Oracle: `CLAUDE.md:261-270`, which states the rule independently of the README (`test/src/**` mirrors `src/**`, and `test/src/concrete/` is reserved for the ordinary deployed contracts in `src/concrete/`), plus this repo's own tree as the worked example of the identical construct — `test/src/abstract/RegistryDeploySnapshot.t.sol` and `test/src/abstract/RegistryDeployChain.t.sol` against subject `src/abstract/RegistryDeploySuites.sol`. Both are prior to and independent of the line being changed.
- Category check: issue asks for the two `.t.sol` paths at README.md:64,67; covered both. Category is "consumer-facing doc prescribing a test file path" — swept `grep -rn "MyDeploy"` and `grep -rn "test/src/concrete"` across all non-`.git` files, and read the natspec of `RainDeployVerifySnapshot.sol`, `RainDeployVerifyChain.sol`, `RainDeployBroadcast.sol` and `RainDeployVerifyBase.sol`. No other doc or natspec prescribes a consumer test path, and the one surviving `test/src/concrete/` mention (`CLAUDE.md:270`) is correctly about this repo's own `src/concrete/` registries.

## Not fixed here

The issue's verification block flags a separate question this fix inherits: `CLAUDE.md:265-268` says a consumer has NOT earned the `src/` scoped exception, so the example's own `src/abstract/MyDeploySuites.sol` line is arguably wrong too. Left alone deliberately — it is a different rule, moving it opens an unanswered question (this repo has no `.t.sol` outside `test/src/**`, so a suites abstract relocated under `test/` has no defined mirror path for its own tests), and the example is internally consistent as it now stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
