### PR TITLE
docs: NoDeployCandidates docstring names its real raise site

### DIFF
--- a/src/abstract/RainDeploySuitesBase.sol
+++ b/src/abstract/RainDeploySuitesBase.sol
@@ -26,9 +26,12 @@ error UnknownDeploymentSuite(string requested, string validSuites);
 /// to declare. When the candidate was a single struct this was true by
 /// construction; a list has to say it.
 ///
-/// Raised from `allSuites`, which is the only way anything reads the
-/// declaration — `suiteNames` and `suiteByName` both go through it — so there
-/// is no reader that answers from an empty one.
+/// Raised from `checkedCandidateSuites` — see there for why the guard sits at
+/// that one read rather than at each reader.
+///
+/// `releasedSuites` is read directly by the chain group and by the frozen
+/// record check, and is untouched by this: a repo with no release is an
+/// ordinary state, and it is the CANDIDATE that the source anchor needs.
 error NoDeployCandidates();
 
 /// One deployable unit: a named snapshot of one contract.
@@ -139,9 +142,10 @@ abstract contract RainDeploySuitesBase {
     /// override this, and a repo inherits exactly one declaration. So the list
     /// is here rather than left to the consumer to assemble.
     ///
-    /// MUST NOT be empty, which `allSuites` enforces. A deploy repo always
-    /// compiles a current source, so there is always something to anchor to —
-    /// see `NoDeployCandidates` for why an empty list is worse than it looks.
+    /// MUST NOT be empty, which `checkedCandidateSuites` enforces. A deploy
+    /// repo always compiles a current source, so there is always something to
+    /// anchor to — see `NoDeployCandidates` for why an empty list is worse
+    /// than it looks.
     /// @return The candidates.
     function candidateSuites() internal pure virtual returns (DeployCandidate[] memory);
 

--- a/test/src/abstract/RainDeploySuitesBase.t.sol
+++ b/test/src/abstract/RainDeploySuitesBase.t.sol
@@ -145,7 +145,7 @@ contract RainDeploySuitesBaseTest is Test {
     /// An empty candidate list reads as a repo with nothing left to declare and
     /// is a repo whose source anchor — the only check that catches a snapshot
     /// of the wrong contract — has been handed nothing to run over. It is
-    /// refused rather than tolerated, and refused on all three readers, because
+    /// refused rather than tolerated, and refused on all four readers, because
     /// a reader that answers from an empty declaration is a reader through
     /// which the whole registry can be empty and green.
     function testNoCandidateReverts() external {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/54 (audit finding `ABS-06`, dimension 4, severity LOW).

## The defect

`src/abstract/RainDeploySuitesBase.sol:29-31` said:

> Raised from `allSuites`, which is the only way anything reads the declaration — `suiteNames` and `suiteByName` both go through it — so there is no reader that answers from an empty one.

Both halves are wrong against the source, which I re-derived at `86f8d96` rather than taking the issue's word:

1. **Wrong raise site.** `revert NoDeployCandidates()` is inside `checkedCandidateSuites`, and that is the only raise site in the repo. `allSuites` merely calls it.
2. **Wrong totality.** `allSuites` is not the only reader of the declaration. `RainDeployVerifySnapshot.sol:257` reads `checkedCandidateSuites()` directly; `RainDeployVerifyChain.sol:134` and `RainDeployVerifySnapshot.sol:265` read `releasedSuites()` directly; and `RainDeployVerifySnapshot.sol:226` calls `allSuites()` directly, so `suiteNames`/`suiteByName` were not even its only callers.

This is worse than an ordinary stale comment because the error's entire justification is a totality argument — *"there is no reader that answers from an empty one"* — so a maintainer coming to check that argument was pointed at the wrong function and told a stronger property than the code has. The file also contradicted itself: `checkedCandidateSuites`'s own docstring, 120 lines below, already stated the correct arrangement.

## The fix

Three sites, all comment-only. No behaviour change.

- **`RainDeploySuitesBase.sol:29-31`** — names `checkedCandidateSuites` as the raise site, and adds the fact stated nowhere else in the file: `releasedSuites` is read directly by the chain group and by the frozen record check and is untouched by the guard, because a repo with no release is an ordinary state and it is the CANDIDATE the source anchor needs.
- **`RainDeploySuitesBase.sol:142`** — "which `allSuites` enforces" becomes "which `checkedCandidateSuites` enforces". The issue's verification block flagged this second site as under-scoped-but-not-wrong.
- **`test/src/abstract/RainDeploySuitesBase.t.sol:148`** — `testNoCandidateReverts`'s docstring said the empty declaration is *"refused on all three readers"* while the body asserts on four (`allSuites`, `suiteNames`, `suiteByName`, `checkedCandidateSuites`), and the very next test's docstring already says "all four readers". Same defect class about the same guard, so it is fixed here rather than left behind.

### One deliberate deviation from the issue's proposed diff

The issue's prose says to make the paragraph agree with `checkedCandidateSuites`'s docstring **"by pointing at it rather than re-arguing it"**, but the literal diff it proposes re-argues it — reproducing the "two spellings of one rule / the reader that got the second spelling wrong silently stops asserting" sentence that already exists almost verbatim at lines 152-155.

I followed the prose over the diff. Copying that sentence would put one claim on two surfaces 120 lines apart, which is exactly the mechanism that produced this defect: this docstring drifted from its sibling because the same rule was spelled twice. Every factual correction the proposed diff makes is in, and its genuinely new content — the `releasedSuites` paragraph — is kept in full; only the duplicated rationale is replaced by a pointer.

## QA

- **Discriminating tests:** n/a — comment-only diff, no behaviour to discriminate. The behaviour the corrected prose describes is already pinned by the existing `testNoCandidateReverts` (`test/src/abstract/RainDeploySuitesBase.t.sol:151`), which asserts `NoDeployCandidates` on all four readers *including* `externalCheckedCandidateSuites` — i.e. the test already encodes the raise-site claim this PR corrects the prose to match. It passes unchanged here (`RainDeploySuitesBaseTest`: 10 passed, 0 failed).
- **Mutations applied:** n/a — a docs-only diff has no executable line to mutate. The equivalent check for prose is that each factual claim in the new text was falsified against source rather than assumed: grep for `revert NoDeployCandidates()` across the repo returns exactly one site, inside `checkedCandidateSuites`; grep for every call site of `allSuites()`, `checkedCandidateSuites()`, `releasedSuites()` and `candidateSuites()` across `src/` and `test/` returns the four direct readers named above, and confirms `candidateSuites()` is never read except through `checkedCandidateSuites`.
- **Oracle:** the source at `86f8d96`, read independently of the issue — I re-derived the raise site and the full reader set by grep rather than accepting the issue's line numbers, and confirmed each before writing. The second oracle is `checkedCandidateSuites`'s own docstring (lines 148-155), the statement the corrected text must agree with and previously contradicted.
- **Category check:** issue asks (a) wrong raise site, (b) false totality claim; its verification block adds (c) the same stale attribution at line 142. Covered a, b and c — plus (d) the same-category staleness in `testNoCandidateReverts`'s docstring, found by sweeping every comment in the repo that makes a claim about this guard rather than only the sites listed. That sweep also cleared README.md:120 and CLAUDE.md:327 (they mention the error but name no raise site) and the remaining `allSuites` comment mentions in `LibRainDeploySnapshot.sol:494,566` and its test, which are about `DuplicateDeploySuite` — genuinely raised in `allSuites`, so correct as they stand.

## Verification

- `forge fmt --check` passes.
- `forge build` passes.
- `forge test`: 168 passed, 47 failed. **Every one of the 47 is `vm.createSelectFork: environment variable *_RPC_URL not found`** — zero non-RPC failures — which is the documented no-`.env` local state (CLAUDE.md: "Fork tests require RPC endpoints defined in `.env` (gitignored)... Those failures are `vm.createSelectFork` errors"). Untouchable by a comment-only diff in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
