### PR TITLE
fix: `candidateContractName` is `pure`, not `view`

### DIFF
--- a/test/src/lib/GeneratedSnapshotShape.t.sol
+++ b/test/src/lib/GeneratedSnapshotShape.t.sol
@@ -123,7 +123,7 @@ contract GeneratedSnapshotShapeTest is RegistryDeploySuites, Test {
     /// declaration whose snapshot is somebody else's.
     /// @param candidate The candidate to name.
     /// @return The contract name.
-    function candidateContractName(DeployCandidate memory candidate) internal view returns (string memory) {
+    function candidateContractName(DeployCandidate memory candidate) internal pure returns (string memory) {
         string[] memory components = vm.split(candidate.snapshot.artifactPath, ":");
         return components[components.length - 1];
     }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/78

## The diff

```diff
-    function candidateContractName(DeployCandidate memory candidate) internal view returns (string memory) {
+    function candidateContractName(DeployCandidate memory candidate) internal pure returns (string memory) {
```

One keyword in `test/src/lib/GeneratedSnapshotShape.t.sol`, exactly the fix the issue proposed.

## Why it is correct

The body calls only `vm.split`, declared `external pure` at `dependencies/forge-std-1.16.1/src/Vm.sol:1301`, against a `memory` argument, and `vm` is a `constant` on `Test`. Nothing is read from state, which is why solc can prove the restriction and emits warning 2018.

`pure` is accepted everywhere `view` was, so the sole caller — `testEveryCandidateHasASnapshot` at line 164 of the same file, itself `view` — needs no change. Those two lines are the only occurrences of the symbol in the tree.

It also puts the helper back in line with its siblings in the same file, which already track what they actually do: `holdsName` and `artifactPath` are `pure`, while `snapshotContractNames`/`nodeTypes`/`constantDeclarations` are `view` because they genuinely call `vm.readDir`/`vm.readFile`. `candidateContractName` was the odd one out, not a deliberate pattern.

## QA

- **Discriminating tests:** none added — `n/a`, and deliberately. State mutability on an `internal` function is a compile-time restriction with no runtime representation: there is no `STATICCALL`, no enforcement, nothing a test can observe. Proven rather than asserted — building both spellings and comparing the artifact for `GeneratedSnapshotShapeTest` gives `bytecode: IDENTICAL (len 39636)` and `deployedBytecode: IDENTICAL (len 39522)`. A forge test that failed on base and passed here cannot exist, so writing one would mean asserting on source text, which this file deliberately does not do (it reads the AST precisely so formatting cannot affect it).
- **Mutations applied:** `test/src/lib/GeneratedSnapshotShape.t.sol:126` `pure` -> `view` (i.e. back to base). **Killed by the compiler, not by a test.** `nix develop -c forge build --force` on the mutant prints `Compiler run successful with warnings:` / `Warning (2018): Function state mutability can be restricted to pure --> test/src/lib/GeneratedSnapshotShape.t.sol:126:5`; on this branch it prints `Compiler run successful!` with no solc warning anywhere in the tree. The mutant SURVIVES the test suite — `forge test --match-contract GeneratedSnapshotShapeTest` is 5 passed / 0 failed under both spellings, with gas identical to the unit (32114, 137663, 249440, 137661, 31717). That survival is the correct result, not a coverage gap: it is the same fact as the identical bytecode above. Behavioural coverage of the function is `testEveryCandidateHasASnapshot`, which is unaffected because the behaviour is unchanged.
- **Oracle:** solc 0.8.25's own mutability analysis, which is independent of this repo — it derived the restriction and named the line before any change was made. Backed by `Vm.sol:1301` declaring `split` as `external pure`, i.e. the reason the analysis is right rather than a restatement of its output.
- **Category check:** the issue asks for exactly one thing — the solc warning 2018 at `GeneratedSnapshotShape.t.sol:126`, with `view -> pure` as the proposed fix and "no caller changes" as the stated ramification. Covered: warning gone, caller verified unchanged, no other occurrence of the symbol. The issue's own verification block additionally observed that a forge-lint `warning[unsafe-typecast]` at `src/lib/LibRainDeploy.sol:304` survives this fix, so the build is not warning-free afterwards. I confirmed it still does. That is a different finding about a different file and is deliberately NOT bundled here; this PR closes the solc-warning finding as filed.

## Other verification

- Full `nix develop -c forge test`: 168 passed, 47 failed. Every one of the 47 is `vm.createSelectFork: environment variable <CHAIN>_RPC_URL not found` — the fork tests CLAUDE.md documents as needing a gitignored `.env`. Environmental, untouched by this diff; CI has the secrets.
- `nix develop -c forge fmt --check` passes; pre-commit hooks pass.