### PR TITLE
Seed `suiteNames`'s named return before the loop

### DIFF
--- a/src/abstract/RainDeploySuitesBase.sol
+++ b/src/abstract/RainDeploySuitesBase.sol
@@ -197,6 +197,10 @@ abstract contract RainDeploySuitesBase {
     /// @return names The declared keys.
     function suiteNames() internal pure returns (string memory names) {
         DeploySuite[] memory suites = allSuites();
+        // Seeded here so every path out of this function assigns `names`,
+        // provable from this body alone. `allSuites` never yields an empty set,
+        // but that is a fact about another function.
+        names = "";
         for (uint256 i = 0; i < suites.length; i++) {
             names = i == 0 ? suites[i].suite : string.concat(names, ", ", suites[i].suite);
         }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/72 (audit finding `CQ4-02`, dimension 4, severity LOW).

## The finding

`suiteNames()` declared the named return `names` and assigned it only inside `for (uint256 i = 0; i < suites.length; i++)`. Judged from this function's body alone, `suites.length == 0` reaches the closing brace with `names` never assigned and returns the empty string.

What actually makes that path unreachable is `checkedCandidateSuites()` reverting `NoDeployCandidates` — two functions away, reached via `allSuites()`. So the return is total, but only via a guard this reader cannot see. That is the org rule's case 1: *assigned only inside a loop, where a guard elsewhere is what makes every path assign it*.

It matters rather than being academic because `names` is the `validSuites` field of `UnknownDeploymentSuite` — the only thing a mistyped `DEPLOYMENT_SUITE` tells a deployer. If the guard in `checkedCandidateSuites` were ever narrowed, this reports "no valid suites" as an empty string instead of failing.

## The change

```solidity
 function suiteNames() internal pure returns (string memory names) {
     DeploySuite[] memory suites = allSuites();
+    // Seeded here so every path out of this function assigns `names`,
+    // provable from this body alone. `allSuites` never yields an empty set,
+    // but that is a fact about another function.
+    names = "";
     for (uint256 i = 0; i < suites.length; i++) {
         names = i == 0 ? suites[i].suite : string.concat(names, ", ", suites[i].suite);
     }
 }
```

Four lines, one of them code.

**The loop and its `i == 0` seed are deliberately untouched**, and mutant M4 below is the evidence they must be: with `names` seeded empty and the ternary dropped, the list comes back as `", address-registry-0-0-1, second-address, ..."`. The ternary is what keeps the first element unprefixed, so folding it into the seed is a behaviour change, not a simplification.

## Why not the fix proposed in the issue body

The issue's "After" block also added `if (suites.length == 0) { return names; }`. The issue's own collapsed verification block flags and rejects that, and I agree on reading the source:

- It is unreachable dead code — `allSuites()` cannot return an empty array.
- It writes into the source the exact thing `checkedCandidateSuites`' NatSpec forbids: *"a reader that answers from an empty declaration is a reader through which the whole registry can be empty and green."*
- `testNoCandidateReverts` asserts `externalSuiteNames()` **reverts** on an empty declaration. An early return is a second, contradictory spelling of that rule sitting in the source.

So this PR implements the minimal remedy the verification block prescribes — seed only, no early return.

## QA

- **Discriminating tests**: none added, and adding one is not possible here — stating that plainly rather than inventing a test. This is a local-provability fix, not a behaviour fix: `names = "";` is only observable on `suites.length == 0`, which `checkedCandidateSuites` makes unreachable by reverting `NoDeployCandidates`. A test that reached the line would first have to disable the guard the repo exists to enforce. The three existing tests that already pin this function are audited below rather than duplicated, per "an existing test that already kills mutants is left as-is": `testSuiteNamesIsTheRegistry`, `testEmptySuiteIsUnknown`, `testUnknownSuiteNamesEveryValidSuite` (all in `test/src/abstract/RainDeploySuitesBase.t.sol`), plus `testNoCandidateReverts` pinning that the empty path reverts rather than answers.
- **Mutations applied**: harness proven live first — unmutated baseline ran **10 tests, 10 passed, 0 failed**, with `testSuiteNamesIsTheRegistry`, `testNoCandidateReverts` and `testEmptySuiteIsUnknown` each named `[PASS]` in the output. Each mutant was greped back out of the file after `sed` to confirm it actually applied, so a no-op edit cannot fake a survival. All against `forge test --match-path test/src/abstract/RainDeploySuitesBase.t.sol`:
  - **M1** — delete `names = "";` (the line this PR adds) → **SURVIVED** (10 passed, 0 failed). Expected and reported as such rather than papered over: the line's whole purpose is to make an *unreachable* path assign, so no test can distinguish its presence. This is the known outcome for this finding class, not a coverage gap.
  - **M2** — `i == 0` → `i == 1` → **KILLED**, 3 failed. `testSuiteNamesIsTheRegistry` (`second-address, address-registry-candidate, second-address-candidate != address-registry-0-0-1, second-address, ...`), `testEmptySuiteIsUnknown`, `testUnknownSuiteNamesEveryValidSuite`. Run *with* the new seed present, which is what proves the seed did not weaken the ternary's coverage.
  - **M3** — separator `", "` → `","` → **KILLED**, 3 failed, same three tests.
  - **M4** — drop the ternary, always `string.concat(names, ", ", suites[i].suite)` → **KILLED**, 3 failed, same three tests, output `", address-registry-0-0-1, ..."` with the leading comma. This is the mutant that proves the `i == 0` branch cannot be collapsed into the seed.
- **Oracle**: the expected key list is independent of `suiteNames`' implementation — it is the registry order declared in the test fixture's own `releasedSuites()`/`candidateSuites()` (`address-registry-0-0-1, second-address, address-registry-candidate, second-address-candidate`), written out longhand as a literal in the test rather than recomputed by concatenating in the assertion. For the empty case the oracle is `checkedCandidateSuites`' NatSpec, which states that every reader must refuse an empty declaration — that is what rules out the early return the issue body proposed.
- **Category check**: the issue asks for exactly one thing — make the assignment total within this function's own body. Covered. The issue body's proposed diff additionally contained an early return; that is deliberately **not** implemented, because the issue's own verification block identifies it as unreachable dead code contradicting `checkedCandidateSuites`' NatSpec and `testNoCandidateReverts`, and prescribes the seed-only remedy instead. No adjacent scope taken: `allSuites`, `checkedCandidateSuites` and `suiteByName` are untouched.

## Full verification run

- `nix develop -c forge build` — clean, exit 0.
- `nix develop -c forge test` with all five RPC endpoints set: **215 passed, 0 failed, 0 skipped** across 17 suites.
- `nix develop -c forge fmt --check` — clean, exit 0.

(Without RPCs, 47 fork tests fail on `vm.createSelectFork: environment variable ..._RPC_URL not found`. That is the requirement documented in CLAUDE.md, not this change — they pass once the endpoints are set, which is the 215/215 above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
