### PR TITLE
Correct checkCodeHash's stated justification in LibMigrationRegistry

### DIFF
--- a/src/lib/LibMigrationRegistry.sol
+++ b/src/lib/LibMigrationRegistry.sol
@@ -103,11 +103,13 @@ library LibMigrationRegistry {
     ///
     /// Verifies the registry's code hash before reading, so a chain where the
     /// registry is absent, or where something else occupies its address, is a
-    /// loud revert rather than a call into unknown code. That distinction is
-    /// the whole point here: "no registry on this chain" and "this migration
-    /// has not been applied" are different facts, and silently collapsing the
-    /// first into the second would send a caller down its pre-migration branch
-    /// on every chain the registry was never deployed to.
+    /// NAMED revert rather than a call into unknown code. An absent registry
+    /// reverts either way — solc reverts a high-level call whose returndata is
+    /// too short to decode — but anonymously, saying nothing about which of the
+    /// two it was. What the check actually forbids is the case that does NOT
+    /// revert: code at the address that is not this registry, an EIP-7702
+    /// delegation included, is free to answer zero to every migration and send
+    /// every caller down its pre-migration branch.
     ///
     /// The registry itself refuses the zero writer, and refuses the two ids a
     /// migration can never be, so those arrive as reverts from it rather than
@@ -129,10 +131,11 @@ library LibMigrationRegistry {
     /// if it has never applied one.
     ///
     /// Verifies the registry's code hash first for the same reason `applied`
-    /// does, and more sharply: a call into an empty account returns nothing,
-    /// which decodes as zero, and zero is the one value a head can never hold —
-    /// so an unverified read would hand back a head that is not a head at all,
-    /// on exactly the chains where nothing has been deployed.
+    /// does, and more sharply: occupying code is free to answer any head it
+    /// likes, including the zero no head can ever hold, so an unverified read
+    /// can hand back something that is not a head at all. An empty address is
+    /// not that case — there is no returndata for a `bytes32` to decode from,
+    /// so it reverts unguarded — and the check is what gives it a name.
     /// @param writer The namespace to read. Never the zero address.
     /// @return The head of `writer`'s namespace. Never zero.
     function head(address writer) internal view returns (bytes32) {
@@ -151,10 +154,12 @@ library LibMigrationRegistry {
     /// one account interleave into one chain.
     ///
     /// Verifies the registry's code hash before writing, so a migration is
-    /// never "applied" into an empty address or into unknown code. A record
-    /// that went nowhere is worse than no record at all: the migration would
-    /// have run, and every reader would go on asserting the pre-migration
-    /// state.
+    /// never "applied" into unknown code. A write into an EMPTY address fails
+    /// unguarded — solc checks the callee exists when no return data is
+    /// expected — so what this stops is the write that SUCCEEDS into something
+    /// that is not the registry: a record that went nowhere is worse than no
+    /// record at all, because the migration ran and every reader goes on
+    /// asserting the pre-migration state.
     ///
     /// The registry refuses the zero id, refuses a migration this caller has
     /// already applied, and refuses one applied onto anything but the

--- a/test/src/lib/LibMigrationRegistry.t.sol
+++ b/test/src/lib/LibMigrationRegistry.t.sol
@@ -262,11 +262,13 @@ contract LibMigrationRegistryTest is Test {
     }
 
     /// A chain with no registry deployed reverts on the code hash rather than
-    /// calling into an empty account. That call would succeed and return
-    /// nothing, which `abi.decode` would read as zero — "this migration has
-    /// not been applied", on every chain the registry was never deployed to,
-    /// which is exactly the silent pre-migration branch this library exists to
-    /// make impossible.
+    /// calling into an empty account, and the point of that is the NAME. An
+    /// empty account has no returndata for `abi.decode` to read, so the call
+    /// reverts unguarded too — anonymously, saying nothing about whether the
+    /// registry is absent or the migration unapplied. Those are different
+    /// facts, and this error is what tells them apart. The case that would
+    /// answer the lie instead of reverting is occupying code, covered by
+    /// `testAppliedWrongCode` and `testAppliedDelegatedCode`.
     function testAppliedNoRegistry(address writer, bytes32 migration) external {
         assertEq(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS.code.length, 0);
 
@@ -280,10 +282,11 @@ contract LibMigrationRegistryTest is Test {
         this.externalApplied(writer, migration);
     }
 
-    /// Reading a head off a chain with no registry is refused for a sharper
-    /// version of the same reason: the empty-account read decodes as zero, and
-    /// zero is a value no head can ever hold, so an unverified read hands back
-    /// something that is not a head at all.
+    /// Reading a head off a chain with no registry is refused for the same
+    /// reason and with the same named error: an unguarded read reverts here
+    /// anyway, because there is no returndata for a `bytes32` to decode from,
+    /// so what the check adds is which chain state it was. A head that is not
+    /// a head is what occupying code can return, not what an empty one does.
     function testHeadNoRegistry(address writer) external {
         assertEq(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS.code.length, 0);
 
@@ -297,10 +300,12 @@ contract LibMigrationRegistryTest is Test {
         this.externalHead(writer);
     }
 
-    /// Writing to a chain with no registry is refused for the mirror reason: an
-    /// `applyMigration` into an empty account is a migration that reports itself
-    /// applied and is not, which leaves every reader asserting the
-    /// pre-migration state forever.
+    /// Writing to a chain with no registry is refused by the code hash rather
+    /// than by solc's own existence check, which an `applyMigration` into an
+    /// empty account hits regardless — no return data is expected, so the
+    /// callee is checked to exist and the write reverts unnamed. A migration
+    /// that reports itself applied and is not is what a write into occupying
+    /// code does, and `testApplyMigrationWrongCode` is where that is covered.
     function testApplyMigrationNoRegistry(bytes32 expectedHead, bytes32 migration) external {
         assertEq(LibMigrationRegistryDeploy.MIGRATION_REGISTRY_DEPLOYED_ADDRESS.code.length, 0);
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/52 (audit finding `MIGREG-1`, dimension 5, severity LOW).

## What was wrong

All three `LibMigrationRegistry` entry points justified `checkCodeHash()` with a mechanism solc does not exhibit. The comments claimed an unguarded call into an empty account returns nothing, decodes as zero, and so silently sends a caller down its pre-migration branch — or, for the write, silently swallows the record.

## Verified, not assumed

I did not take the issue's word for the mechanism. I compiled a probe under this repo's own settings (`solc = "0.8.25"`, optimizer, `optimizer_runs = 100000`, `evm_version = "cancun"`) driving the three call shapes the library uses as high-level typed interface calls, exactly as the library makes them:

| target | `applied`-shaped (`uint256`) | `head`-shaped (`bytes32`) | `applyMigration`-shaped (void) |
|---|---|---|---|
| empty address | `ok=false`, rdlen 0 | `ok=false`, rdlen 0 | `ok=false`, rdlen 0 |
| occupying code returning 32 zero bytes | `ok=true` -> `0x00..` | `ok=true` -> `0x00..` | `ok=true` |
| EIP-7702 designator (23-byte code) | `ok=true` -> `0x00..` | - | - |

An absent registry **reverts in all three directions**. Nothing decodes as zero and no write silently succeeds. For the returning calls solc skips the `extcodesize` check because return data is expected, and the ABI decoder reverts on 0 bytes of returndata; for the void call solc emits the existence check and reverts.

So the empty-address case the comments led with was already safe without the guard — what the guard buys there is a **named, diagnosable** error instead of a bare revert. The case that genuinely answers a lie, and that the comments never stated as the reason, is the one the suite already covers: unrelated code or an EIP-7702 delegation occupying the deterministic address, free to answer any timestamp, any head, or a silent success for a write.

The probe was removed before committing; it is not part of this diff.

## The change

Comments only, in two files:

- `src/lib/LibMigrationRegistry.sol` — the three rationales on `applied`, `head` and `applyMigration` now state the real mechanism: the absent registry reverts anonymously either way, and the check is what names it and what forbids the occupying-code case that does *not* revert.
- `test/src/lib/LibMigrationRegistry.t.sol` — the three `*NoRegistry` test rationales restated the same wrong mechanism, so they propagated it; corrected the same way, each now pointing at the `*WrongCode` / `*DelegatedCode` tests that cover the case which actually returns a wrong answer.

No assertion, no behaviour and no bytecode changes. Every changed line starts with `///`, so the deterministic address and codehash pins are untouched. The tests already assert the named `UnexpectedMigrationRegistryCodeHash`, which is exactly the behaviour the corrected wording claims.

The `checkCodeHash()` natspec itself and the sibling `LibAddressRegistry.sol` already stated an accurate rationale and are unchanged.

## QA

- Discriminating tests: `n/a` — the diff changes only `///` comment prose. There is no code path whose behaviour a new test could discriminate, and every existing assertion is byte-for-byte unchanged. What the change asserts is a claim ABOUT the compiler, and that claim was verified empirically (see Oracle) rather than by a suite test. Existing coverage of the corrected mechanism is already present and passing: `testAppliedWrongCode`, `testHeadWrongCode`, `testApplyMigrationWrongCode`, `testAppliedDelegatedCode`, `testHeadDelegatedCode`, `testApplyMigrationDelegatedCode` cover the occupying-code case the corrected prose names, and the three `*NoRegistry` tests cover the absent case.
- Mutations applied: `n/a` — a docs-only diff has no executable lines to mutate. Confirmed structurally: every added and removed line in `git diff` begins with `///`, and the compiled artifacts are unchanged, which the repo's own codehash/snapshot pin tests independently attest (the snapshot and registry-deploy suites pass, and those fail on any bytecode movement).
- Oracle: the solc compiler itself, not the implementation and not the issue text. I built a throwaway probe under this repo's exact `foundry.toml` settings that makes the same three high-level typed calls against (a) an address with no code, (b) an address etched with `0x60206000f3` (returns 32 zero bytes to any call), and (c) an EIP-7702 designator `0xef0100 || delegate`, and recorded `success` and returndata length for each. Results are the table above. The empty-address row falsifies the old prose; the occupying-code and delegated rows establish the new prose. This is independent of `LibMigrationRegistry` — the probe does not import it.
- Category check: issue asks for (A) the three source rationales at `src/lib/LibMigrationRegistry.sol:104-110, 131-135, 153-157`, and (B) the same correction applied to the three test rationales at `test/src/lib/LibMigrationRegistry.t.sol:264-269, 283-286, 300-303`. Covered A and B, both in full. The issue's exact proposed replacement text was used verbatim for A; for B the issue specified the correction without giving text, so the wording is mine and states the same verified mechanism. Deliberately NOT covered, as outside the filed scope: pinning the compiler behaviour as a permanent regression test so the prose cannot drift back, and the pre-existing "Both entry points check" in the `checkCodeHash()` natspec (there are three). Say the word and I will file or fold in either.

## Checks

- `forge fmt --check` — exit 0.
- `forge test` — 168 passed, 47 failed, and **all 47** failures are `vm.createSelectFork: environment variable *_RPC_URL not found`, the local `.env` absence CLAUDE.md documents. Zero non-RPC failures.
- `LibMigrationRegistryTest` — 23 passed, 0 failed.
- pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
