### PR TITLE
docs: drop the false "AddressRegistry is the only concrete" premise

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,10 +1,11 @@
 name: Package Release
-# Deploy repo: a manual `sol-v*` tag is the sole release trigger. This repo now
-# carries a deployed concrete (`AddressRegistry`) whose address + codehash
-# consumers pin, which is exactly the shape rainix-tag-release exists for and
-# exactly the shape rainix-autopublish's merge-driven, next-version lifecycle is
-# wrong for: autopublish bumps [package].version on every merge while the frozen
-# deploy tag only advances at deploy time.
+# Deploy repo: a manual `sol-v*` tag is the sole release trigger. This repo
+# carries deployed concretes (`AddressRegistry`, `MigrationRegistry`) whose
+# address + codehash consumers pin, which is exactly the shape
+# rainix-tag-release exists for and exactly the shape rainix-autopublish's
+# merge-driven, next-version lifecycle is wrong for: autopublish bumps
+# [package].version on every merge while the frozen deploy tag only advances at
+# deploy time.
 #
 # The tag names the version; rainix-tag-release runs `cutRelease()`, which
 # freezes src/generated/<tag>/ AND regenerates the released-suites lib that

--- a/test/abstract/ExampleDeploySuites.sol
+++ b/test/abstract/ExampleDeploySuites.sol
@@ -25,12 +25,17 @@ import {MockDeployableV2} from "../concrete/MockDeployableV2.sol";
 ///
 /// The `MockDeployableV2` entries exist for one reason: every loop here runs
 /// over a list, and proving a loop does not stop at the first entry requires a
-/// second entry at a DIFFERENT address. `AddressRegistry` is the only concrete
-/// in this repo, so the second address comes from `MockDeployableV2`, which is
-/// already on main for `LibRainDeploy`'s own tests. Without it, "the matrix
-/// silently checks only the first suite" is undetectable — the failure mode
-/// that matters most to the repos this abstract exists for, where ten suites
-/// sit at ten addresses.
+/// second entry at a DIFFERENT address. That second address comes from
+/// `MockDeployableV2` rather than from this repo's other concrete,
+/// `MigrationRegistry`, because this is a fixture for the abstracts and not a
+/// copy of `RegistryDeploySuites`: it borrows ONE real snapshot, which is what
+/// makes the released and candidate paths real, and derives the second entry's
+/// creation code, address and hashes inline from a mock type. So what the
+/// abstracts are tested against is written here in full, and adding or removing
+/// a contract in `src/concrete/` does not change it. Without a second address,
+/// "the matrix silently checks only the first suite" is undetectable — the
+/// failure mode that matters most to the repos this abstract exists for, where
+/// ten suites sit at ten addresses.
 ///
 /// It appears on BOTH sides for that reason, once as a release and once as a
 /// candidate. The released side is the chain matrix's second address; the

--- a/test/src/abstract/RainDeployVerifyChain.t.sol
+++ b/test/src/abstract/RainDeployVerifyChain.t.sol
@@ -60,8 +60,9 @@ import {
 /// leaves the etch in place and changes only the code, and the check still
 /// fails, which it could not do if the expectation were read from the etch.
 contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain {
-    /// The second suite's address, derived from the only other creation code in
-    /// this repo.
+    /// The second suite's address, derived from `MockDeployableV2`'s creation
+    /// code by the same derivation `ExampleDeploySuites` declares, so the etch
+    /// in `setUp` lands on the address the matrix reads.
     /// @return The address.
     function secondDeployedAddress() internal pure returns (address) {
         return LibRainDeploy.zoltuAddress(type(MockDeployableV2).creationCode);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/75

## What was wrong

`MigrationRegistry` is a second concrete in `src/concrete/`, declared as a candidate in `RegistryDeploySuites` and carrying its own generated snapshot under `src/generated/candidate/`. Every doc that justifies itself with "`AddressRegistry` is the only concrete/creation code in this repo" is therefore asserting something false.

## Departure from the issue's proposed wording — please read

The issue proposes replacing the false premise with a chain-safety rationale: the second address must be a freely-etchable mock *"rather than a second real registry whose pinned address the chain matrix also asserts about"*.

**I did not use that wording, because it would have replaced one false statement with another.** Two sibling files argue at length for the opposite, and they are right:

- `test/src/abstract/RainDeployVerifyChain.t.sol:52-55` — *"Pointing the fixture at a mock nobody deploys would move that dependency rather than remove it: the Zoltu factory is permissionless, so no address is structurally unoccupiable. Etching the state the assertion is about is what removes it."*
- `test/src/abstract/RainDeployVerifyChainCandidate.t.sol:75-80` — makes the same argument for the candidate's absence.

So a mock is *not* structurally safer than a real registry here; the etch is what makes either safe. The proposed rationale also does not distinguish the two entries, since the fixture's **first** entry is already a real deployed address (`AddressRegistry`) that the fixtures etch and empty. And `RegistryDeployChainTest` reads `releasedSuites()`, which is empty — this repo has released nothing — so "the real chain group asserts about it too" is not true of any address today.

Restated instead as the reason that actually holds and is checkable from the code: this is a fixture for the abstracts, not a copy of `RegistryDeploySuites`, so what the abstracts are tested against is written in the file rather than tracking whatever `src/concrete/` currently holds. That is what makes swapping `MockDeployableV2` for `MigrationRegistry` the wrong move — the thing the paragraph exists to prevent.

## Scope: three instances, not one

The issue cites one line; the same falsehood appears three times, so this covers the category.

1. `test/abstract/ExampleDeploySuites.sol:28-30` — the cited one, and the one that matters: it argued *for* a change that would collapse the "loop does not stop at the first entry" coverage.
2. `test/src/abstract/RainDeployVerifyChain.t.sol:63-64` — called `MockDeployableV2` "the only other creation code in this repo". Restated as the load-bearing fact: it is the same derivation `ExampleDeploySuites` declares, which is why the `setUp` etch lands on the address the matrix reads.
3. `.github/workflows/package-release.yaml:2-3` — named a single deployed concrete. Its sibling `manual-sol-artifacts.yaml` already names both.

## QA

- **Discriminating tests:** n/a — the diff changes only comment text and a YAML comment. There is no behaviour to discriminate: no test can fail on base and pass here, because nothing this repo executes reads a comment. The relevant assertion is factual accuracy of the prose, checked against source below rather than by a test.
- **Mutations applied:** n/a — a docs-only diff has no executable line to mutate. Mutating any comment character produces an identical build and an identical 215-test result, which is the definition of no mutable surface.
- **Oracle:** the repo's own source, read independently of the comments being fixed. `ls src/concrete/` returns `AddressRegistry.sol` and `MigrationRegistry.sol`; `ls src/generated/candidate/` returns snapshots for both; `RegistryDeploySuites.candidateSuites()` builds a length-2 array from `addressRegistryCandidate()` and `migrationRegistryCandidate()`; `CLAUDE.md` names both as ordinary deployed contracts. That is what falsifies "the only concrete". For the *replacement* text, the oracle is the sibling reasoning quoted above (`RainDeployVerifyChain.t.sol:52-55`, `RainDeployVerifyChainCandidate.t.sol:75-80`) plus `migrationRegistryCandidate()`'s `dependencies: new address[](0)` — which is why the issue's proposed chain-safety rationale has no mechanical basis and was not used.
- **Category check:** the issue asks for one line (`ExampleDeploySuites.sol:28-30`). The category is "docs asserting `AddressRegistry` is the repo's only concrete/creation code". `grep -rn "only concrete\|only other creation code" --include=*.sol` finds 2 hits, both fixed; a sweep for single-concrete claims in workflows/docs found a 3rd in `package-release.yaml`, also fixed. Covered: all 3. Not covered: nothing in this category remains — the same greps return only the corrected text.

## Verification

Documentation only — no behavioural change, no deployed bytecode touched.

- `forge fmt --check` — clean
- `forge build` — clean
- `forge test` with all five fork RPCs configured — **215 passed, 0 failed, 0 skipped** across 17 suites, including the chain/fork suites that consume both edited Solidity files
- pre-commit (`yamlfmt`, `no-consumer-prettier`) — passed on the workflow edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
