### PR TITLE
test: assert the empty-derivation early return forks nothing

### DIFF
--- a/test/src/abstract/RainDeployVerifyChain.t.sol
+++ b/test/src/abstract/RainDeployVerifyChain.t.sol
@@ -147,6 +147,44 @@ contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain
         assertEq(block.chainid, lastChainId);
     }
 
+    /// The early return for an empty set is about having NOTHING to check, not
+    /// about the networks: handed ONE derivation, the matrix forks.
+    ///
+    /// The count is the whole point of the case. Every other test here runs the
+    /// matrix over this contract's TWO released suites, so a guard keyed
+    /// anywhere below two — `derived.length < 2` — returns early on every
+    /// subject in the repo and is caught by none of them:
+    /// `RainDeployVerifyChainCandidateTest` is the only other contract that
+    /// reaches the matrix with a subject, at exactly one, and it forks on its own
+    /// before calling, so a matrix that returned without forking is
+    /// indistinguishable there. `RegistryDeployChainTest`'s empty case reads as
+    /// satisfied under that guard, which is what makes one subject the length
+    /// that discriminates.
+    ///
+    /// This contract is where it belongs because it already forks every
+    /// supported network. Asserting it from the empty-set side would hand the
+    /// contract that exists to need no RPC endpoint the five-endpoint dependency
+    /// the early return removes from it.
+    function testChainWithASingleSubjectDoesFork() external {
+        (bool activeBefore,) = address(vm).call(abi.encodeWithSignature("activeFork()"));
+        assertFalse(activeBefore, "a fork was selected before the call");
+
+        // One subject, and `setUp` left it etched persistently, so it is live
+        // with its recorded hash on whichever forks the matrix creates and the
+        // check itself passes on all of them.
+        DerivedDeploy[] memory derived = new DerivedDeploy[](1);
+        derived[0] = DerivedDeploy({
+            suite: "address-registry-0-0-1",
+            deployedAddress: ADDRESS_REGISTRY_DEPLOYED_ADDRESS,
+            bytecodeHash: ADDRESS_REGISTRY_BYTECODE_HASH
+        });
+
+        checkDeployedOnSupportedNetworks(derived);
+
+        (bool activeAfter,) = address(vm).call(abi.encodeWithSignature("activeFork()"));
+        assertTrue(activeAfter, "the matrix checked a subject without forking");
+    }
+
     /// Code on a network that is not the code the version's creation code
     /// produces MUST fail hard, naming the network and BOTH hashes.
     ///

--- a/test/src/abstract/RegistryDeployChain.t.sol
+++ b/test/src/abstract/RegistryDeployChain.t.sol
@@ -26,4 +26,37 @@ import {RegistryDeploySuites} from "../../../src/abstract/RegistryDeploySuites.s
 /// it says this and nothing more: a missing deployment or an unreachable
 /// endpoint fails here alone, leaving every snapshot assertion to answer for
 /// itself.
-contract RegistryDeployChainTest is RegistryDeploySuites, RainDeployVerifyChain {}
+contract RegistryDeployChainTest is RegistryDeploySuites, RainDeployVerifyChain {
+    /// Nothing to check MUST NOT touch an RPC endpoint. This repo has released
+    /// nothing, so this is the branch every CI run takes: forking five networks
+    /// to check nothing turns an outage into the failure of an assertion with
+    /// no subject, which is the one failure this contract exists to stay
+    /// legible against.
+    ///
+    /// The ABSENCE of a fork is what is asserted, because the pass is identical
+    /// either way — the matrix that forks all five and finds nothing to check on
+    /// each of them passes too, and is the only thing this contract would have
+    /// done differently. `vm.activeFork()` reverts when nothing is selected, so
+    /// the low-level call failing IS "no network was reached".
+    ///
+    /// It runs the whole inherited entry point rather than handing the matrix an
+    /// empty array, so the derivation is inside what is asserted: a fork opened
+    /// while deriving would touch the same five endpoints for the same nothing.
+    ///
+    /// The empty released set is asserted rather than assumed, because it is the
+    /// premise and not the property. The first release gives this contract a
+    /// subject and the matrix will fork for it — correctly — so this fails at
+    /// that release naming what actually changed, instead of reporting that a
+    /// matrix with nothing to check forked, which would by then be false.
+    function testChainWithNothingToCheckForksNothing() external {
+        assertEq(releasedSuites().length, 0, "this repo has released something, so the matrix has a subject");
+
+        (bool activeBefore,) = address(vm).call(abi.encodeWithSignature("activeFork()"));
+        assertFalse(activeBefore, "a fork was selected before the call");
+
+        this.testSuitesLiveOnEverySupportedNetwork();
+
+        (bool activeAfter,) = address(vm).call(abi.encodeWithSignature("activeFork()"));
+        assertFalse(activeAfter, "the matrix forked a network with nothing to check");
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/63 (audit `cov-10`, LOW).

## The gap

`checkDeployedOnSupportedNetworks` returns before touching any RPC endpoint when there is nothing to check, and nothing observed it. `RegistryDeployChainTest` has released nothing, so it takes that branch on every CI run — and passed identically with the early return deleted, simply forking all five supported networks, finding nothing to check on each, and passing. The property under test was the absence of the forks, which no test looked at.

## What is asserted

**`test/src/abstract/RegistryDeployChain.t.sol` — `testChainWithNothingToCheckForksNothing`.** `vm.activeFork()` reverts when no fork is selected, so a failing low-level call to it IS "no network was reached". Two departures from the issue's sketch, both to make the assertion mean what it says:

- It runs the whole inherited entry point rather than handing the matrix an empty array, so the derivation is inside what is asserted — a fork opened while deriving touches the same five endpoints for the same nothing.
- It asserts the empty released set as a **premise**, because that is not the property. The first release gives this contract a subject and the matrix will then fork for it, correctly; without the premise this would fail at that release reporting that a matrix with nothing to check forked, which would by then be false.

**`test/src/abstract/RainDeployVerifyChain.t.sol` — `testChainWithASingleSubjectDoesFork`.** The complement, placed per the issue's own verification-block caveat: it goes in the contract that already forks every supported network, never beside the empty case, because asserting it there would hand the one contract that exists to need no RPC endpoint the five-endpoint dependency the early return removes from it.

It runs at **one** subject, and the count is the point. Every other test in that contract runs the matrix over its two released suites, so a guard keyed anywhere below two returns early on every subject in the repo and no existing test sees it — `RainDeployVerifyChainCandidateTest` is the only other contract that reaches the matrix with a subject, at exactly one, and it forks on its own before calling, so a matrix that returned without forking is indistinguishable there.

No `src/` change — this PR is tests only.

## QA

- Discriminating tests: `testChainWithNothingToCheckForksNothing` (`test/src/abstract/RegistryDeployChain.t.sol`), `testChainWithASingleSubjectDoesFork` (`test/src/abstract/RainDeployVerifyChain.t.sol`) — both pass on the unmutated baseline at `ce1e371`, and each fails under the mutation of the exact line it is about, verified by applying the mutant to `src/abstract/RainDeployVerifyChain.sol` in the working tree and re-running `forge test` (the baseline was committed first, so the revert is `git checkout -- src/...`). Neither existed on base, so "fails on base" is verified as the mutation table below: on base the guard is unasserted, and the first mutant reproduces base's own untested state.
- Mutations applied:
  - `src/abstract/RainDeployVerifyChain.sol:115-117` → delete the `if (derived.length == 0) { return; }` guard entirely → killed by `testChainWithNothingToCheckForksNothing` (`FAIL: the matrix forked a network with nothing to check`).
  - `src/abstract/RainDeployVerifyChain.sol:115` → `derived.length == 0` → `derived.length < 2` → killed by `testChainWithASingleSubjectDoesFork` (`FAIL: the matrix checked a subject without forking`). The other **8** chain tests all PASSED under this mutant — including `testChainMatrixReachesTheLastSupportedNetwork`, `testChainMatrixCoversEverySupportedNetwork`, `testChainIgnoresAnUndeployedCandidate` and the new empty-set test — which is the evidence that one subject is the only length in the repo that discriminates, and why the complement is not a duplicate of the existing "the matrix does run" tests.
- Oracle: the natspec on `checkDeployedOnSupportedNetworks` itself, which states the guard's purpose ("Nothing to check is not a reason to touch five RPC endpoints"), plus `RegistryDeployChainTest`'s contract natspec and `CLAUDE.md`, which both state "it forks nothing and passes" as a repo property. The expected values come from that stated intent, not from the implementation: the observable is `vm.activeFork()`'s documented revert-when-nothing-selected behaviour, independent of anything `RainDeployVerifyChain` computes, and the fork counts are never read back from the code under test.
- Category check: issue asks for (A) an assertion that the empty-derivation case touches no RPC endpoint, and (B) the complement so (A) is not satisfied by a matrix that never forks at all — covered A and B. The issue's collapsed verification block additionally rules that (B) must NOT live in `RegistryDeployChain.t.sol`, since that would re-impose the five-endpoint dependency on the one contract the guard frees from it; (B) is therefore in `RainDeployVerifyChainTest`, which already forks, as that ruling directs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
