### PR TITLE
docs: add the soldeer install step to CLAUDE.md's command block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ environment management.
 # Enter the nix dev shell (provides forge and all tooling)
 nix develop
 
+# Install the dependencies declared in foundry.toml (dependencies/ is
+# gitignored, so this is required on a fresh checkout before anything builds)
+nix develop -c forge soldeer install
+
 # Build
 nix develop -c forge build
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/80 (audit finding `PROC-07`, severity LOW).

## The defect

`dependencies/` is gitignored (`.gitignore` line 2) and `remappings.txt` points every import at `dependencies/forge-std-1.16.1/` and `dependencies/rain-sol-codegen-0.1.6/`. CLAUDE.md's Build & Development block went straight from `nix develop` to `nix develop -c forge build`, with no install step anywhere in the file and no pointer to README, so the block's own first build command fails on a fresh clone.

Reproduced on a fresh clone of `main` before the change:

```
$ nix develop -c forge build
Error (6275): Source "dependencies/forge-std-1.16.1/src/Test.sol" not found: File not found.
 --> test/src/lib/LibRainDeploy.t.sol:5:1
```

The error text names `remappings`, which is the misdirection the issue describes: a session reads it as a broken remapping, a bad `soldeer.lock` or a missing nix package and edits `remappings.txt` or `foundry.toml` instead of installing dependencies.

The block is also captioned as what the three CI matrix tasks run. All three rainix reusable workflows — `rainix-sol-static.yaml`, `rainix-sol-legal.yaml`, `rainix-sol-test.yaml` — carry an explicit `Install soldeer dependencies` step running `... #sol-shell -c forge soldeer install`, guarded on `soldeer.lock` existing. So the omission made that caption false as well: CI ran a command the block did not list.

## The diff

```diff
 # Enter the nix dev shell (provides forge and all tooling)
 nix develop
 
+# Install the dependencies declared in foundry.toml (dependencies/ is
+# gitignored, so this is required on a fresh checkout before anything builds)
+nix develop -c forge soldeer install
+
 # Build
 nix develop -c forge build
```

Exactly the fix the issue proposes, at the position it names. Documentation only — no source, config or generated file is touched, so no pin, snapshot or deterministic address can move.

README is untouched — line 348 already documents `forge soldeer install`. This closes the inconsistency between the two copies rather than introducing a third.

## QA

- Discriminating tests: n/a as automated tests — the diff is a comment block in a markdown file, and nothing in this repo asserts CLAUDE.md's content, so no Solidity test could fail on it. The discriminating check is the executable one the document makes a claim about, run on a fresh `git clone` of `main` with no `dependencies/`: `nix develop -c forge build` — the block's first build command — FAILS ON BASE with `Error (6275): Source "dependencies/forge-std-1.16.1/src/Test.sol" not found` (exit 1), and passes after running the line this PR adds (`forge soldeer install` exit 0, then `forge build` exit 0). The base failure was observed first, on the unmodified clone, before the edit existed.
- Mutations applied: n/a — a docs-only diff has no executable line to mutate; there is no branch, guard or literal in it whose inversion any suite could observe. The equivalent adversarial probe is deleting the added command from the documented sequence and re-running it, which is exactly the base state that fails above.
- Oracle: independent of this repo's docs. (1) forge itself, which does not auto-install soldeer dependencies — established by running it, not by reading a claim about it. (2) The rainix reusable workflows read from `rainlanguage/rainix` at HEAD, each carrying an `Install soldeer dependencies` step, which fixes what the block's "what they run" caption must say. (3) `.gitignore` line 2 and `remappings.txt`, which are what make the directory absent and the imports unresolvable. No step of the expectation was derived from CLAUDE.md, the file under change.
- Category check: the issue asks for one thing — the dependency install step added to CLAUDE.md's Build & Development command block, after `nix develop`, so the documented first command works on a fresh checkout. Covered, at that exact position, in the issue's own wording. Checked the whole class rather than only the cited example: every other command in that block is `nix develop -c ...` against tooling the shell itself provides, and `.env` — the only other gitignored prerequisite in the repo — already has its own documented section. No second instance of this defect exists in the file, so this is a `Closes`, not a `Refs`.

Pre-commit (the rainix static toolchain) ran on the commit and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
