### PR TITLE
test: drive the deployToNetworks dependency loop past index 0

### DIFF
--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -610,6 +610,40 @@ contract LibRainDeployTest is Test {
         );
     }
 
+    /// `deployToNetworks` MUST check EVERY dependency, not only the first. The
+    /// missing one here is the LAST, behind a dependency that really is
+    /// present, so a loop that stopped after `dependencies[0]` would broadcast
+    /// — and a contract whose constructor reads an address with no code is
+    /// broken at a deterministic address that can never be redeployed.
+    function testDeployToNetworksMissingLaterDependencyReverts() external {
+        string[] memory networks = new string[](1);
+        networks[0] = LibRainDeploy.ARBITRUM_ONE;
+
+        address[] memory dependencies = new address[](2);
+        // Present on arbitrum: the Zoltu factory, which the deploy needs
+        // anyway. Index 0 therefore passes and only a loop that reaches index 1
+        // reverts at all.
+        dependencies[0] = LibRainDeploy.ZOLTU_FACTORY;
+        dependencies[1] = address(0xdead);
+
+        // The revert names the LAST dependency, so a loop that reached index 1
+        // but reported index 0 fails here too.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibRainDeploy.MissingDependency.selector, LibRainDeploy.ARBITRUM_ONE, address(0xdead)
+            )
+        );
+        this.externalDeployToNetworks(
+            networks,
+            address(this),
+            type(MockDeployable).creationCode,
+            "",
+            mockDeployableAddress(),
+            bytes32(0),
+            dependencies
+        );
+    }
+
     /// `zoltuAddress` MUST derive the address the Zoltu factory actually
     /// deploys the given creation code to, and creation code that differs MUST
     /// derive a different address.
@@ -1056,6 +1090,42 @@ contract LibRainDeployTest is Test {
         networks[0] = LibRainDeploy.ARBITRUM_ONE;
         address[] memory dependencies = new address[](1);
         dependencies[0] = LibRainDeploy.ZOLTU_FACTORY;
+
+        address result = this.externalDeployToNetworks(
+            networks,
+            address(this),
+            type(MockDeployable).creationCode,
+            "test/concrete/MockDeployable.sol:MockDeployable",
+            mockDeployableAddress(),
+            mockDeployableCodeHash(),
+            dependencies
+        );
+        assertEq(result, mockDeployableAddress());
+        assertEq(result.codehash, mockDeployableCodeHash());
+    }
+
+    /// `deployToNetworks` MUST deploy when a dependency list LONGER than one is
+    /// entirely present, so `testDeployToNetworksMissingLaterDependencyReverts`
+    /// is about the missing entry rather than about the list having more than
+    /// one entry at all.
+    function testDeployToNetworksEveryDependencyPresentDeploys() external {
+        // A second present dependency, distinct from the Zoltu factory.
+        // Deployed here rather than pinned to a mainnet address that happens to
+        // have code on arbitrum today, and made persistent so it is present on
+        // the fork `deployToNetworks` creates for itself as well as this one.
+        // Stated rather than assumed: if it had no code the deploy below would
+        // succeed for a reason that has nothing to do with the loop.
+        vm.createSelectFork(LibRainDeploy.ARBITRUM_ONE);
+        address dependency = this.externalDeployZoltu(type(MockDeployableV2).creationCode);
+        assertGt(dependency.code.length, 0);
+        vm.makePersistent(dependency);
+
+        string[] memory networks = new string[](1);
+        networks[0] = LibRainDeploy.ARBITRUM_ONE;
+
+        address[] memory dependencies = new address[](2);
+        dependencies[0] = LibRainDeploy.ZOLTU_FACTORY;
+        dependencies[1] = dependency;
 
         address result = this.externalDeployToNetworks(
             networks,


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/60 (audit finding `cov-07`, dimension 2, severity LOW).

## The gap

Every `dependencies` array that actually reached `deployToNetworks` was length 0 or 1. `testDeployToNetworksMissingDependencyReverts` put the missing dependency at index 0 and `testDeployToNetworksPresentDependencyDeploys` put a present one at index 0, so only "the loop runs at all" was pinned — a loop bounded `j < 1`, or one reading `dependencies[0]` every iteration, passed the entire suite. A deploy would then broadcast to a network where the second dependency has no code, and a contract whose constructor bakes in a missing address is broken at a deterministic address that can never be redeployed.

The sibling loops already had this property pinned, which is what made it an inconsistency rather than a deliberate scope. Of the four loops in `src/lib/LibRainDeploy.sol`, the networks loops had `testDeployToNetworksMultipleNetworks` and the `readCalls` loop had `testCheckResolvedAddressesChecksEveryRead` — each an explicit two-element test with a comment saying a loop stopping early would fail. The dependency loop was the only one left unpinned past index 0.

## The tests

`testDeployToNetworksMissingLaterDependencyReverts` — the discriminator. The missing dependency is at the LAST index, behind the Zoltu factory, which is genuinely present on arbitrum, so index 0 passes and only a loop that reaches index 1 reverts at all. The expected revert names `0xdead`, so a loop that reached index 1 but reported index 0 fails here too.

`testDeployToNetworksEveryDependencyPresentDeploys` — its complement, so the first test is about the missing entry rather than about the list being longer than one.

## Mutation proof

Both mutants die, and each is killed by the new test and nothing else — every pre-existing dependency test passes under both, which is the reported gap reproduced:

| mutation | result |
|---|---|
| baseline | 5 passed, 0 failed |
| `j < dependencies.length` -> `j < 1` | 4 passed, **1 failed** — `testDeployToNetworksMissingLaterDependencyReverts` |
| `dependencies[j]` -> `dependencies[0]` (read + revert) | 4 passed, **1 failed** — `testDeployToNetworksMissingLaterDependencyReverts` |

Under both mutants the deploy proceeds past the check and the test fails on the deploy having happened, which is the failure the property is about.

## Two deliberate departures from the issue's proposed fix

**1. The second present dependency is not `BASE_GENESIS_PREDEPLOY`.** The issue's own verification block suspected this, and it is correct — `cast code 0x4200000000000000000000000000000000000006` on arbitrum returns `0x`. That address is a Base genesis predeploy with no code on arbitrum, so the proposed test would have failed its own `assertGt`.

Rather than the issue's fallback (reuse `ZOLTU_FACTORY` for both entries plus a third address), the test deploys `MockDeployableV2` via the real Zoltu factory on the fork and makes it persistent, so `dependencies[1]` is a distinct address that is genuinely present. This keeps the two entries distinct without pinning the test to some mainnet address that happens to have code on arbitrum today and might not tomorrow, and it reuses the `makePersistent` pattern `testDeployToNetworksSkipsAlreadyDeployedWithMissingDependency` already uses.

**2. `assertEq(mockDeployableAddress().code.length, 0)` is omitted.** The issue proposed it to show "the check guards the broadcast rather than reporting after it". It cannot fail. The whole `this.externalDeployToNetworks(...)` call reverts, so any deploy inside it is rolled back regardless of whether the check ran before or after the broadcast — and the fork selection is rolled back with it, leaving the read on a fork where the address is empty for a reason unrelated to the property. There is no observation point outside a reverting call from which the guard's position is visible, so the assertion would read as pinning something it does not pin. The mutation table above is what actually establishes the property.

## Scope

Test-only. No `src/` change — the loop is correct as written; what was missing was the coverage proving it.

## QA
- Discriminating tests: `testDeployToNetworksMissingLaterDependencyReverts` (the discriminator) and `testDeployToNetworksEveryDependencyPresentDeploys` (its complement). These do NOT fail on base: `src/lib/LibRainDeploy.sol` is correct as written and this PR fixes a coverage gap, not a defect, so there is no broken base to fail against. What they fail on is the mutated loop — verified by applying each mutation to `src/lib/LibRainDeploy.sol:419-423`, re-running, and restoring with `git checkout HEAD -- src/lib/LibRainDeploy.sol` (tree confirmed clean afterwards). Baseline before mutating: 5 passed, 0 failed.
- Mutations applied:
  - `LibRainDeploy.sol:419` `for (uint256 j = 0; j < dependencies.length; j++)` -> `for (uint256 j = 0; j < 1; j++)` -> killed by `testDeployToNetworksMissingLaterDependencyReverts` (4 passed, 1 failed).
  - `LibRainDeploy.sol:420-422` `dependencies[j]` -> `dependencies[0]` in the log, the `.code.length` read and the `revert MissingDependency(...)` -> killed by `testDeployToNetworksMissingLaterDependencyReverts` (4 passed, 1 failed).
  - Under both, all four pre-existing dependency tests PASSED — the surviving-mutant claim in the issue reproduced exactly. Neither mutant is killed by the complement test, which is expected: an all-present list still deploys under a shortened loop, so the complement is scope-fixing, not discriminating.
- Oracle: derived from the natspec contract on `deployToNetworks` ("every dependency must have code ... read on that network's own fork immediately before broadcasting") and from CLAUDE.md's dependency-checking pattern, not from the loop body. The expected revert `MissingDependency(ARBITRUM_ONE, 0xdead)` names the LAST entry, so reaching index 1 and misreporting index 0 also fails. Dependency presence was established independently of the library, by `cast code <addr> --rpc-url $ARBITRUM_RPC_URL` against live arbitrum: `0x7A0D...6D12` (Zoltu factory) returns 31 bytes, `0x4200...0006` returns `0x` — which is why the issue's suggested `BASE_GENESIS_PREDEPLOY` is not used.
- Category check: the issue asks for (a) a test where the missing dependency is not the first entry and (b) a longer all-present list proving (a) is about the missing entry rather than the length. Both covered. Widened past the issue's two examples to the whole category — every loop in `src/lib/LibRainDeploy.sol` — and the other three were already pinned past index 0: both `networks` loops (`:341`, `:401`) by `testDeployToNetworksMultipleNetworks` and the `readCalls` loop (`:281`) by `testCheckResolvedAddressesChecksEveryRead`. The dependency loop was the only one outstanding, so nothing further is in category.
- Full suite on the branch: 217 passed, 0 failed, 0 skipped across 17 suites. `forge fmt --check` clean.
