### PR TITLE
test: name the deployable mocks' mutable storage `sFoo`

### DIFF
--- a/test/concrete/MockDeployable.sol
+++ b/test/concrete/MockDeployable.sol
@@ -6,5 +6,5 @@ pragma solidity =0.8.25;
 /// Minimal contract used as a deployment target for Zoltu factory tests.
 contract MockDeployable {
     /// @notice Placeholder value to ensure the contract has non-trivial code.
-    uint256 public value = 42;
+    uint256 public sValue = 42;
 }

--- a/test/concrete/MockDeployableV2.sol
+++ b/test/concrete/MockDeployableV2.sol
@@ -8,9 +8,9 @@ pragma solidity =0.8.25;
 /// bytecode has changed while its pinned constants have not.
 contract MockDeployableV2 {
     /// @notice Placeholder value to ensure the contract has non-trivial code.
-    uint256 public value = 43;
+    uint256 public sValue = 43;
 
     /// @notice Second placeholder value so the runtime code also differs from
     /// `MockDeployable`.
-    uint256 public other = 99;
+    uint256 public sOther = 99;
 }

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -373,7 +373,7 @@ contract LibRainDeployTest is Test {
         // now pinned exactly in `foundry.toml`, because this repo's deploy pins
         // depend on them; that is what makes a literal here stable at all, and
         // moving any of them moves this address.
-        assertEq(deployed, 0x0c04367b381F8Ca252aD2516F1Eac2b9B2ca928F);
+        assertEq(deployed, 0x7DA611e4146dCf0107407Bb331599acC53E8B62c);
     }
 
     /// `deployZoltu` MUST revert with `DeployFailed` when the Zoltu factory


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/76 (audit finding `CQ4-07`, dimension 4, severity LOW).

## What

`MockDeployable.value`, `MockDeployableV2.value` and `MockDeployableV2.other` were the only mutable state declarations in the repo that did not carry their storage class. The rule is followed everywhere else without exception — the test harness contracts (`sRegistry`, `sDeploy`, `sSuites`), the production concretes (`sAddresses`, `sApplied`, `sHead`), and the immutables in the two sibling mocks in this same directory (`iOwner`, `iWord`), which is what rules out "mocks are exempt".

## The ramification, and how the literal was regenerated

All three are `public`, so the rename moves their generated getter selectors and with them the runtime and creation code of both mocks. Confirmed rather than assumed:

| getter | selector |
| --- | --- |
| `value()` | `0x3fa4f245` |
| `sValue()` | `0xd933a829` |
| `other()` | `0x85295877` |
| `sOther()` | `0x97754b68` |

`0xd933a829` is the selector visible in the new creation code in the fork trace, so the rename demonstrably reached the bytecode.

`LibRainDeployTest.testDeployZoltu` pins a literal address rather than deriving one, deliberately — the comment above it says the live factory is the oracle, so an expected value taken from `zoltuAddress` would only check that function against itself. The new literal `0x7DA611e4146dCf0107407Bb331599acC53E8B62c` is what the live Zoltu factory on an Arbitrum One fork actually returned for the new creation code, taken from the factory's own return value in the trace, **not** re-derived from `zoltuAddress`. That preserves the property the pin exists for.

## What did NOT need regenerating

The issue's proposed-fix text named two things that turn out not to move; the issue's own verification block already corrects both. Checked here rather than taken on trust:

- `ZOLTU_EMPTY_CREATION_CODE_ADDRESS` derives from EMPTY creation code, so `MockDeployable` cannot move it.
- Every `MockDeployableV2` address is computed live via `LibRainDeploy.zoltuAddress(type(MockDeployableV2).creationCode)` and `keccak256(type(MockDeployableV2).runtimeCode)`, so the V2 rename is free.

A grep for 40-hex address literals across `test/` confirms line 376 was the only pin tied to `MockDeployable`'s creation code, and the old literal `0x0c04367b…` now appears nowhere in the repo. No caller anywhere reads `.value()` or `.other()`, so there is no consumer to update.

## QA

- **Discriminating tests:** `testDeployZoltu` (test/src/lib/LibRainDeploy.t.sol:365) — fails on base. Verified by running it with the three mocks renamed and the pinned literal left at its old value: `Suite result: FAILED. 7 passed; 1 failed`, `[FAIL: assertion failed: 0x7DA611e4146dCf0107407Bb331599acC53E8B62c != 0x0c04367b381F8Ca252aD2516F1Eac2b9B2ca928F]`. 8 tests ran in that run, so the suite demonstrably executed rather than being filtered to nothing. This is a naming-convention change with no new behaviour to assert, so no new test is added — the pre-existing pin is what proves the bytecode moved and that the recorded address followed it.
- **Mutations applied:**
  - `test/concrete/MockDeployable.sol:9` — `sValue` reverted to `value`, new literal left in place → **KILLED** by `testDeployZoltu` (8 tests ran; 7 passed, 1 failed). The failure reported the address as exactly the old `0x0c04367b381F8Ca252aD2516F1Eac2b9B2ca928F`, which pins the causal claim: the address delta comes from this rename and nothing else.
  - `test/src/lib/LibRainDeploy.t.sol:376` — literal replaced with the old pre-change address `0x0c04367b…` → **KILLED** by `testDeployZoltu` (8 tests ran; 7 passed, 1 failed).
  - `test/concrete/MockDeployableV2.sol:15` — `sOther` reverted to `other` → **SURVIVED**; full suite still 215 passed, 0 failed. Reported as a survivor rather than dressed up as a kill. It is not a coverage gap: it is the direct experimental confirmation of the claim above that every `MockDeployableV2` address is derived live, so the V2 rename has no pinned consumer to update. A naming convention is not a behaviour, so there is nothing a test could assert here.
  - **Non-viable mutant, explicitly not counted:** flipping the final nibble of the pinned literal (`…62c` → `…62d`) does not compile — solc rejects it with `Error (9429): This looks like an address but has an invalid checksum`. That run produced zero test output, which a naive filter would have scored as a silent pass. It was re-run as the valid-checksum mutant above instead.
- **Oracle:** the live Zoltu factory at `0x7A0D94F55792C434d74a40883C6ed8545E406D12` on an Arbitrum One fork, read as the factory's own return value in the `forge test -vvv` trace. Independent of the implementation under test — `LibRainDeploy.zoltuAddress` is not consulted for the expected value, which is the whole reason this pin is a literal.
- **Category check:** the issue asks for three renames (`MockDeployable.value`, `MockDeployableV2.value`, `MockDeployableV2.other`) plus regeneration of the pinned literal in the same change. Covered: all three renamed, literal regenerated from the live factory. The issue's two proposed-fix inaccuracies (`ZOLTU_EMPTY_CREATION_CODE_ADDRESS`, the V2 addresses) were re-checked against source and confirmed to need no change, matching the issue's verification block.

## Verification

- Baseline before the change: `forge test` — 215 passed, 0 failed, 17 suites. Recorded first precisely so any post-change red would be attributable, and so the old literal was confirmed to genuinely hold against the live factory rather than being stale.
- After the change: `forge test` — 215 passed, 0 failed, 17 suites. Same count; the only test that moved is `testDeployZoltu`.
- `forge fmt --check` clean. Fork tests ran against real Arbitrum, Base, Base Sepolia, Flare and Polygon endpoints.
