### PR TITLE
docs: version is the last publish, not a name for a snapshot that exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,8 +394,10 @@ expected addresses, expected code hashes, and dependency lists.
   network before anything migrates onto it.
 - **Deploy-repo lifecycle**: a manual `sol-v*` tag is the sole release trigger
   (`rainix-tag-release`), because this repo carries deployed concretes whose
-  pins consumers rely on. `[package].version` is the LAST released version and
-  moves only in lockstep with its snapshots.
+  pins consumers rely on. `[package].version` is the version of the LAST Soldeer
+  publish, and it moves only in lockstep with the frozen `src/generated/<tag>/`
+  record that release writes. A version published before this lifecycle has no
+  such record.
 - **Deploy, then verify, then tag** — in that order, and they are three separate
   things. `script/Deploy.sol` broadcasts the suite `DEPLOYMENT_SUITE` names to
   every network in `supportedNetworks()`, dispatched by hand through

--- a/README.md
+++ b/README.md
@@ -307,10 +307,12 @@ Three separate steps, in this order. Nothing automatic ever broadcasts.
 
 This is a deploy repo: it carries deployed concretes whose addresses and
 codehashes consumers pin, so releases are **manual `sol-v*` tags**, not merges.
-`[package].version` is the LAST released version, naming the current
-`src/generated/<tag>/` snapshots, and only a release moves it. Every version
-published under the previous merge-driven lifecycle stays published; consumers
-pin exact versions and are unaffected.
+`[package].version` is the version of the LAST Soldeer publish, and only a
+release moves it. A release cut under this lifecycle also names the frozen
+`src/generated/<tag>/` record `cutRelease()` wrote for it. Every version
+published under the previous merge-driven lifecycle predates that record and has
+none, so `src/generated/` holds no directory for it; those versions stay
+published, and consumers pin exact versions and are unaffected.
 
 ## Install
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,10 @@
 [package]
 name = "rain-deploy"
-# Deploy repo: this is the LAST released version, naming the current
-# src/generated/<tag>/ snapshot, not a next-version slot. A normal PR does not
-# bump it; only a `sol-v*` tag release moves it, in lockstep with the snapshot.
+# Deploy repo: this is the version of the LAST Soldeer publish, not a
+# next-version slot. A normal PR does not bump it; only a `sol-v*` tag release
+# moves it, in lockstep with the frozen src/generated/<tag>/ record that release
+# writes. A version published before this lifecycle has no such record, so
+# src/generated/ holds no directory for it.
 version = "0.1.5"
 
 # SPDX-License-Identifier: LicenseRef-DCL-1.0

--- a/src/lib/LibRainDeploySnapshot.sol
+++ b/src/lib/LibRainDeploySnapshot.sol
@@ -72,7 +72,7 @@ error EmptyRelease(string tag);
 library LibRainDeploySnapshot {
     /// The rolling snapshot's directory name. A sibling of the frozen tag
     /// directories rather than a file beside them, so `src/generated/` reads as
-    /// `candidate/ 0_1_5/ 0_1_6/` and "which one is current" is answered by
+    /// `candidate/ 0_1_6/ 0_1_7/` and "which one is current" is answered by
     /// looking.
     string constant CANDIDATE = "candidate";
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/67

## The claim that did not hold

`README.md:310-311` and `foundry.toml:3-5` both stated `[package].version` is
"the LAST released version, **naming the current `src/generated/<tag>/`
snapshots**". The appositive is false: `version = "0.1.5"`, `src/generated/`
holds only `candidate/`, and both `releasedSuites()` libs return empty arrays.

I checked why, rather than assuming. `sol-v0.1.5` is a real Soldeer release
(published 2026-07-30, confirmed live in the Soldeer registry — 0.1.5 is the
latest published `rain-deploy`, and 0.1.6 was never published). Its tag tree has
**no `src/generated/` at all**: the snapshot machinery landed after it. So no
`0_1_5/` record was ever written, and none can be — `cutRelease()` freezes to
`deployTag(vm)`, read from `foundry.toml`, and 0.1.5 is already published.

The "LAST released version" half is true and deliberate. Only the clause about
naming an existing snapshot directory was wrong.

## The fix

Reworded so the rule holds in **both** windows instead of describing a transient
state:

- version is the version of the LAST Soldeer publish;
- a release cut under this lifecycle also names the frozen
  `src/generated/<tag>/` record `cutRelease()` wrote for it;
- a version published before this lifecycle has none, so `src/generated/` holds
  no directory for it.

That last line is what a reader seeing `0.1.5` beside a lone `candidate/` needs
to reconcile the two, and it stays true after the first tag. I deliberately did
**not** take the issue's suggested wording verbatim: it said `src/generated/`
"currently holds `candidate/` and nothing else", which becomes false at the
first release and would trade one stale sentence for another. Naming 0.1.5
explicitly has the same problem; the rule does not.

An earlier draft was discarded for being newly false rather than merely stale:
it said "from the first `sol-v*` tag onward", but `sol-v0.1.4` and `sol-v0.1.5`
already exist (the old merge-driven workflow cut them) and froze nothing.

## Beyond the two sites the issue cites

The issue names README and foundry.toml. The same claim appears in a third
place, so I fixed the category rather than the examples:

- `CLAUDE.md:397-398` — "`[package].version` is the LAST released version and
  moves only in lockstep with **its snapshots**". Same false possessive.
- `src/lib/LibRainDeploySnapshot.sol:75` — illustrated the layout as
  `candidate/ 0_1_5/ 0_1_6/`, naming a directory that provably can never exist.
  Now `candidate/ 0_1_6/ 0_1_7/`, consistent with the `0.1.7` example ten lines
  below it.

A repo-wide grep confirms the only remaining `0.1.5` is `foundry.toml`'s actual
`version` value.

## QA

- Discriminating tests: n/a — the diff changes only markdown prose, a TOML
  comment and a Solidity docstring. Nothing in the repo reads any of these four
  sites: no test, script, workflow or pin parses README/CLAUDE.md prose, and
  `deployTag()` reads `[package].version` (unchanged, still `"0.1.5"`) via
  `parseTomlString`, which ignores TOML comments. There is no behavior to
  discriminate on, so a test here could only assert the text of a sentence.
- Mutations applied: n/a — a docs-only diff has no executable lines to mutate.
  The generated-lib docstrings that *are* asserted
  (`LibRainDeploySnapshot.sol:638` against `LibRainDeploySnapshot.t.sol:316`)
  are untouched by this diff; `:75` is a source comment, not generated output.
- Oracle: external to the repo's own prose, which is the thing under suspicion.
  The Soldeer registry API (`api.soldeer.xyz/api/v1/revision`) gives 0.1.5 as
  the newest published revision (2026-07-30T17:14:56Z) with no 0.1.6;
  `git ls-tree -r sol-v0.1.5 -- src/generated` is empty; `git log -p
  foundry.toml` shows the old autopublish bumping to 0.1.6 and a later commit
  setting it back to 0.1.5; `.github/workflows/package-release.yaml` confirms
  the tag names the version and `cutRelease()` writes the frozen record.
- Category check: issue cites README.md:310-313 and foundry.toml:3-5; covered
  both, plus CLAUDE.md:397-398 and LibRainDeploySnapshot.sol:75, which carry the
  same false claim and were not cited. Category is "prose asserting that
  `[package].version` names an existing `src/generated/<tag>/` snapshot"; a
  repo-wide grep for `0_1_5|0.1.5|LAST released|naming the current` shows no
  remaining instance.

## Build/test state

- `pre-commit` (the repo's CI static toolchain): all hooks pass. `denofmt`
  rewrapped my markdown on the first attempt; that rewrap is included.
- `forge build`: clean, exit 0. The one lint warning
  (`LibRainDeploy.sol:304 unsafe-typecast`) is pre-existing and untouched.
- `forge test`: 168 passed, 47 failed **locally**. All 47 are
  `vm.createSelectFork: environment variable BASE_RPC_URL/ARBITRUM_RPC_URL not
  found` — I grepped every `[FAIL` line and **zero** have any other cause. Those
  are fork tests needing RPC secrets that CI supplies via `secrets: inherit`.

Note the first `forge test` I ran appeared to exit 0 while actually failing to
compile (deps not installed, exit code swallowed by a pipe to `tail`). The
numbers above are from a re-run with the real exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
