### PR TITLE
Suppress unsafe-typecast lint on the range-checked uint160 cast

### DIFF
--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -301,6 +301,12 @@ library LibRainDeploy {
             if (word > type(uint160).max) {
                 revert ResolvedAddressReadFailed(network, target, i, returnData);
             }
+            // Casting to `uint160` is safe because the range check directly
+            // above rejects every word with dirty upper 96 bits, so the low 160
+            // bits are the whole of the word and the cast keeps every one.
+            // Excluded at the site rather than repo-wide so an unchecked cast
+            // added anywhere else is still reported.
+            // forge-lint: disable-next-line(unsafe-typecast)
             address actual = address(uint160(word));
             if (actual != expectedAddresses[i]) {
                 revert UnexpectedResolvedAddress(network, target, i, expectedAddresses[i], actual);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/49

## What

`checkResolvedAddresses` decodes a static-call answer as a `uint256` word and
range checks it against `type(uint160).max` — reverting `ResolvedAddressReadFailed`
on a word with dirty upper 96 bits — before casting it to an address. forge-lint
cannot see that guard, so it warned `unsafe-typecast` on the cast on every build
of every consumer of this library.

The cast is safe. This suppresses the lint at the site with the reason, which is
the house style already in this same file eighteen lines above:

- `src/lib/LibRainDeploy.sol:282-286` — `slither-disable-next-line low-level-calls`,
  with a comment saying it is excluded at the site "rather than repo-wide so a
  low-level call added anywhere else is still reported"
- `src/lib/LibRainDeploySnapshot.sol:157` — this exact lint, same directive
- `src/concrete/MigrationRegistry.sol:117-119` — `block-timestamp`, same shape

Line 304 was the one suppressible site in `src/`, `script/` or `test/` that had
skipped it.

Comment-only. No behaviour changes.

## Verification

Reproduced and then confirmed fixed with the repo's own toolchain
(`nix develop -c forge build --force`, forge 1.7.2-nightly from the flake).

Before, on `main` at `86f8d96`:

```
warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ src/lib/LibRainDeploy.sol:304:38
    │
304 │             address actual = address(uint160(word));
    │                                      ━━━━━━━━━━━━━
```

After: no `warning[unsafe-typecast]` anywhere in the build.

- `forge fmt --check` passes.
- `forge test`: identical results on this branch and on `main` — 168 passing and
  47 failing on both, and the failing test-name sets are identical between the
  two runs. Every one of those 47 is `vm.createSelectFork: environment variable
  <NETWORK>_RPC_URL not found`, i.e. the fork tests this sandbox has no `.env`
  for, exactly as `CLAUDE.md` documents. Pre-existing and unrelated; CI supplies
  the endpoints.

The pinned deploy snapshots cannot move: `bytecode_hash = "none"` and
`cbor_metadata = false`, so comments are not in the creation code, and
`LibRainDeploy.sol` is a `Vm`-importing script library that is not in the pinned
contracts' compile graph at all. `GeneratedSnapshotShapeTest`,
`LibRainDeploySnapshotTest`, `RainDeployVerifySnapshotTest` and
`RegistryDeploySnapshotTest` all pass unchanged.

## QA

- **Discriminating tests**: `testCheckResolvedAddressesDirtyWordReverts(bytes32)`
  in `test/src/lib/LibRainDeploy.t.sol` — not a test this PR adds, but the test
  that makes the suppression honest. A `forge-lint: disable` is only ever as good
  as the claim in the comment beside it, and the claim here is that the range
  check rejects every word with dirty upper 96 bits. That fuzz test drives
  exactly those words and asserts `ResolvedAddressReadFailed`, so the
  justification is enforced rather than merely asserted. Its own docstring
  already names the failure mode a wrong suppression would hide: "truncating the
  word silently PASSES this check against an address the read never gave".

  For the comment itself the discriminating check is the build, run both ways on
  this exact toolchain — mutation 1 below.
- **Mutations applied**:
  1. The new comment block at `src/lib/LibRainDeploy.sol:304` -> deleted
     (`git checkout main -- src/lib/LibRainDeploy.sol`) -> `forge build --force`
     emits `warning[unsafe-typecast]` again (count 1); restored -> count 0. So
     this diff is what removes the warning, not something incidental to it.
  2. The guard itself, `src/lib/LibRainDeploy.sol:301-303`
     `if (word > type(uint160).max) { revert ResolvedAddressReadFailed(...); }`
     -> deleted entirely, which makes the cast genuinely truncating and the new
     suppression comment a lie -> **killed by**
     `testCheckResolvedAddressesDirtyWordReverts`:
     `[FAIL: next call did not revert as expected]`.

  Harness honesty for mutation 2, because a "killed" verdict is worthless if the
  run was fake: the unmutated baseline `[PASS]`ed at `runs: 256`, so the test
  really executes; the mutant reported `Compiler run successful!`, so its failure
  is an assertion failure and not a build error masquerading as one; the guard
  was confirmed absent in the mutant (`grep -c` = 0) and present again after
  restore (= 1); and `git status` is clean afterwards.
- **Oracle**: forge-lint's own output, independent of both the source comment and
  of me — it either emits `warning[unsafe-typecast]` for that span or it does
  not. forge-lint also printed the exact remedy it wanted
  (`// forge-lint: disable-next-line(unsafe-typecast)`), and the in-repo
  convention sites listed above fix the comment's wording shape, so neither the
  directive nor the style is my invention. For mutation 2 the oracle is the
  interface contract — a read answering a non-address word must surface as
  `ResolvedAddressReadFailed` naming network, target and index — taken from that
  error's declared purpose, not from the implementation.
- **Category check**: the issue carries two findings (`Q4-04`, `LIBDEPLOY-05`)
  proposing the same single fix — suppress this lint at this one site with a
  justification. Covered. Treating the category as "suppressible lint sites
  lacking their justified suppression" rather than only the one cited line, I
  checked it is a category of one: after this change `forge build --force` emits
  no `warning[...]` forge-lint diagnostic of any kind across `src/`, `script/`
  and `test/`. The one remaining build warning is a solc `Warning (2018)`, a
  different category, deliberately out of scope — see below.

## One correction to the issue

Both findings state this was the repo's only unsuppressed warning. It was the
only unsuppressed **forge-lint** warning, which is what this fixes, but the same
build also emits an unsuppressed solc warning:

```
Warning (2018): Function state mutability can be restricted to pure
   --> test/src/lib/GeneratedSnapshotShape.t.sol:126:5
```

`LIBDEPLOY-05`'s own verification block already noted this and used it to argue
the severity down. It is a different category — a real code change to a test
helper, not a missing suppression — and neither finding proposed fixing it, so it
is out of scope here and left alone. Worth its own issue if a zero-warning build
is the actual goal, since this PR alone does not achieve one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
