### PR TITLE
test: assert [rpc_endpoints] and [etherscan] are exactly supportedNetworks()

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -68,6 +68,10 @@ polygon = "${POLYGON_RPC_URL}"
 # these variable names, so a deploy without this section broadcasts and then
 # fails with no API key configured for the chain — after spending the gas. One
 # entry per `[rpc_endpoints]` alias, because the deploy goes to all of them.
+#
+# Both sections are checked against `LibRainDeploy.supportedNetworks()`, in both
+# directions, by `testSupportedNetworksAreFullyConfigured`. Adding a network is
+# an edit to all three or a red test, not a broadcast that discovers it.
 [etherscan]
 arbitrum = { key = "${CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY}" }
 base = { key = "${CI_DEPLOY_BASE_ETHERSCAN_API_KEY}" }

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -203,6 +203,70 @@ contract LibRainDeployTest is Test {
         assertEq(networks[4], LibRainDeploy.POLYGON);
     }
 
+    /// Whether `names` holds `name`. A config section is keyed, not ordered, so
+    /// membership is the only thing worth asserting across one.
+    /// @param names The names to search.
+    /// @param name The name to look for.
+    /// @return Whether it is there.
+    function holdsName(string[] memory names, string memory name) internal pure returns (bool) {
+        for (uint256 i = 0; i < names.length; i++) {
+            if (keccak256(bytes(names[i])) == keccak256(bytes(name))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// PROPERTY: `[rpc_endpoints]` and `[etherscan]` in `foundry.toml` are
+    /// EXACTLY `supportedNetworks()`, which makes the three lists one list.
+    ///
+    /// The deploy forks by the first and `--verify` resolves the second, so a
+    /// supported network missing from either broadcasts and then fails after
+    /// the gas is spent, and a section entry no supported network names is
+    /// config nothing ever reads. Both are the same defect — the lists having
+    /// drifted — so both directions are asserted, by membership: containment
+    /// one way alone passes for a section carrying an alias nothing deploys
+    /// to, and the other way alone passes for a network with no config at all.
+    ///
+    /// This is what makes the `[etherscan]` half enforced at all. The RPC half
+    /// is enforced only incidentally, by the fork tests, and only forwards.
+    ///
+    /// The raw file is read rather than forge's resolved config because the
+    /// values are `${VAR}` interpolations that exist only in CI. The KEYS are
+    /// the whole contract here, and they are in the text — so this needs no
+    /// RPC and fails on the PR that drifts rather than at dispatch time.
+    function testSupportedNetworksAreFullyConfigured() external view {
+        string memory config = vm.readFile("foundry.toml");
+        string[] memory networks = LibRainDeploy.supportedNetworks();
+
+        for (uint256 i = 0; i < networks.length; i++) {
+            assertTrue(
+                vm.keyExistsToml(config, string.concat(".rpc_endpoints.", networks[i])),
+                string.concat("supported network has no [rpc_endpoints] alias: ", networks[i])
+            );
+            assertTrue(
+                vm.keyExistsToml(config, string.concat(".etherscan.", networks[i])),
+                string.concat("supported network has no [etherscan] key: ", networks[i])
+            );
+        }
+
+        string[] memory rpcAliases = vm.parseTomlKeys(config, ".rpc_endpoints");
+        for (uint256 i = 0; i < rpcAliases.length; i++) {
+            assertTrue(
+                holdsName(networks, rpcAliases[i]),
+                string.concat("[rpc_endpoints] alias is not a supported network: ", rpcAliases[i])
+            );
+        }
+
+        string[] memory etherscanKeys = vm.parseTomlKeys(config, ".etherscan");
+        for (uint256 i = 0; i < etherscanKeys.length; i++) {
+            assertTrue(
+                holdsName(networks, etherscanKeys[i]),
+                string.concat("[etherscan] key is not a supported network: ", etherscanKeys[i])
+            );
+        }
+    }
+
     /// `ZOLTU_FACTORY_CODEHASH` MUST match the actual codehash of the Zoltu
     /// factory on every supported network. Every name in `supportedNetworks`
     /// MUST also be a configured fork alias, otherwise it cannot be deployed


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/47

## What was wrong

"Which networks this org deploys to" was spelled three times with nothing joining them:

- `LibRainDeploy.supportedNetworks()` (`src/lib/LibRainDeploy.sol:237-245`)
- `[rpc_endpoints]` (`foundry.toml:60-65`)
- `[etherscan]` (`foundry.toml:71-76`)

Only one pairing was enforced, and only incidentally: `testZoltuFactoryCodehash` forks every name `supportedNetworks()` returns, so a name with no `[rpc_endpoints]` alias fails there. Nothing in the repo read `[etherscan]` at all — grep over `src/`, `script/` and `test/` for `readFile|parseToml|keyExists` finds only `.package.version`, artifact JSON reads and snapshot record reads.

The consequence is the one `foundry.toml:67-70` already documents and then leaves to memory: `rainix-manual-sol-artifacts` passes `--verify`, so a network in `supportedNetworks()` with no `[etherscan]` entry broadcasts, spends the gas, and *then* fails with no API key configured for the chain.

## The fix

`testSupportedNetworksAreFullyConfigured` in `test/src/lib/LibRainDeploy.t.sol` reads `foundry.toml` and asserts both sections are EXACTLY `supportedNetworks()`.

Asserted in **both directions, by membership**:

- every supported network has an `[rpc_endpoints]` alias and an `[etherscan]` key — a missing one is the broadcast-then-fail above;
- every `[rpc_endpoints]` alias and every `[etherscan]` key is a supported network — a stray one is config nothing ever reads.

One direction alone is not enough: containment forwards passes for a section carrying an alias nothing deploys to, and containment backwards passes for a network with no config at all. Membership both ways makes the sets equal, so the three lists can only be one list.

Membership rather than the key counts the issue proposed. It is strictly stronger — equal counts plus forward containment is only set equality if `supportedNetworks()` has no duplicates, which this test would then be leaning on `testSupportedNetworks` to guarantee — and the failure names the offending alias instead of only reporting that two numbers differ.

The raw file is read rather than forge's resolved config, because the values are `${VAR}` interpolations that only exist in CI. The keys are the whole contract here and they are in the text — so the test needs no RPC and fails on the PR that drifts, rather than at dispatch time with a hot key.

`fs_permissions` already granted `{ access = "read", path = "./foundry.toml" }` and `LibRainDeploySnapshot.deployTag` already reads that file the same way, so no config change was needed.

The only non-test change is a comment on `[etherscan]` naming the test that now enforces it, so the next person editing that section learns it is checked rather than rediscovering the hazard.

## Mutation evidence

Five mutants, one per drift direction. Every run was checked for `1 total tests` as well as for `[FAIL`, so a mutant that failed to compile could not be miscounted as killed.

| # | mutant | killed with |
|---|---|---|
| M1 | 6th network in `supportedNetworks()`, no config at all | `supported network has no [rpc_endpoints] alias: optimism` |
| M2 | 6th network + `[rpc_endpoints]` alias, `[etherscan]` missed — **the hazard in the issue** | `supported network has no [etherscan] key: optimism` |
| M3 | stray `[rpc_endpoints]` alias | `[rpc_endpoints] alias is not a supported network: optimism` |
| M4 | stray `[etherscan]` key | `[etherscan] key is not a supported network: optimism` |
| M5 | `[etherscan]` entry deleted | `supported network has no [etherscan] key: polygon` |

M2 is the scenario both findings describe end to end, and it is the one nothing in the repo caught before this test.

## Scope

Test-only plus one comment. No behaviour change: `supportedNetworks()`, `[rpc_endpoints]` and `[etherscan]` are all untouched and already agree.

## QA
- Discriminating tests: `testSupportedNetworksAreFullyConfigured` — fails on base under each of the five drifts below (verified by applying each mutation to a base tree via `.fixes/mutate.sh` and running `forge test --match-test`; each run asserted `1 total tests` actually RAN as well as `[FAIL`, so a non-compiling mutant cannot be miscounted as killed). It is a new test: before it nothing in the repo read `[etherscan]`, so the base suite is green on every mutant below.
- Mutations applied: `LibRainDeploy.supportedNetworks()` `new string[](5)` → `new string[](6)` + `networks[5] = "optimism"` → killed by `testSupportedNetworksAreFullyConfigured` (`supported network has no [rpc_endpoints] alias: optimism`); that same mutation plus `optimism` added to `[rpc_endpoints]` — the exact hazard the issue describes — → killed by `testSupportedNetworksAreFullyConfigured` (`supported network has no [etherscan] key: optimism`); `foundry.toml` `[rpc_endpoints]` += `optimism` with the library untouched → killed (`[rpc_endpoints] alias is not a supported network: optimism`); `foundry.toml` `[etherscan]` += `optimism` with the library untouched → killed (`[etherscan] key is not a supported network: optimism`); `foundry.toml` `[etherscan]` −= `polygon` → killed (`supported network has no [etherscan] key: polygon`). 5 mutants, 5 killed.
- Oracle: `LibRainDeploy.supportedNetworks()`, which is what the deploy actually iterates (`RainDeployBroadcast.deployNetworks()` defaults to it). The expected key sets are never restated in the test — they are read from `supportedNetworks()` at runtime and compared against keys parsed out of the `foundry.toml` text, so the test cannot drift from the list it is about. The consequence being guarded is stated independently by `foundry.toml:67-70` and by `rainix-manual-sol-artifacts` passing `--verify`.
- Category check: the issue asks for both `[rpc_endpoints]` and `[etherscan]` asserted against `supportedNetworks()` in both directions; covered — `[rpc_endpoints]` forward and reverse, `[etherscan]` forward and reverse. Implemented by membership rather than the proposed key counts: strictly stronger (count equality is only set equality given no duplicates in `supportedNetworks()`, which the count form would be leaning on `testSupportedNetworks` to supply) and it names the offending alias on failure instead of only reporting that two numbers differ. No `fs_permissions` change was needed, as both findings predicted.
