### PR TITLE
One spelling of the record root, pinned to the writer's

### DIFF
--- a/src/abstract/RainDeployVerifySnapshot.sol
+++ b/src/abstract/RainDeployVerifySnapshot.sol
@@ -260,6 +260,25 @@ abstract contract RainDeployVerifySnapshot is RainDeployVerifyBase {
     /// Every release in the frozen record MUST be declared, so that the set the
     /// chain group checks is every release this repo has ever cut rather than
     /// the ones somebody remembered to list.
+    ///
+    /// An empty walk passes, and is meant to: that is the state of every deploy
+    /// repo before its first release. What makes it safe is that the root is
+    /// the one a snapshot is WRITTEN to — `LIB_FS_ROOT` is the only spelling of
+    /// it in `LibRainDeploySnapshot` and `testRecordRootIsTheRootTheWriterWritesTo`
+    /// pins it against `LibFs`'s. Under the writer's own root, finding nothing
+    /// means there is nothing; under any other, the walk returns an empty list
+    /// forever, this passes with no subject, and the one check standing between
+    /// a release dropping out of everything and a green suite is inert.
+    ///
+    /// Deliberately NOT also guarded by comparing the record's size against the
+    /// declaration's. The two are emitted one-for-one by `writeReleasedSuitesLib`
+    /// for a repo that generates its declaration from its record, but this is
+    /// inherited by any repo that overrides `releasedSuites`, and a declaration
+    /// with no record behind it is a state such a repo is legitimately in: a
+    /// release deployed before it adopted this machinery has no frozen record
+    /// and never will. A size check would red-line that permanently with no way
+    /// to spell the exemption, while the release it names goes on being checked
+    /// by everything anchored to a chain.
     function testEveryFrozenSnapshotIsReleased() external view {
         checkFrozenSnapshotsReleased(
             LibRainDeploySnapshot.frozenSnapshotPaths(vm, LibRainDeploySnapshot.LIB_FS_ROOT), releasedSuites()

--- a/src/lib/LibRainDeploySnapshot.sol
+++ b/src/lib/LibRainDeploySnapshot.sol
@@ -160,11 +160,22 @@ library LibRainDeploySnapshot {
         return string(tagBytes);
     }
 
+    /// The output root `LibFs` writes to, and the only one it can write to:
+    /// `LibFs.pathForContract` hardcodes it.
+    ///
+    /// The only spelling of that root in this library. Everything here that
+    /// names the root — the directory a snapshot is written into, and the tree
+    /// the frozen record is walked from — reads it, so a root this library
+    /// walks that is not a root it writes to is not a state it can be in. The
+    /// remaining pair, this and `LibFs`'s own, is what
+    /// `testRecordRootIsTheRootTheWriterWritesTo` pins.
+    string constant LIB_FS_ROOT = "src/generated";
+
     /// The directory holding a snapshot, rolling or frozen.
     /// @param dir The snapshot directory name — a release tag, or `CANDIDATE`.
     /// @return The directory path.
     function dirForSnapshot(string memory dir) internal pure returns (string memory) {
-        return string.concat("src/generated/", dir);
+        return string.concat(LIB_FS_ROOT, "/", dir);
     }
 
     /// The contract name that places a generated file inside a snapshot
@@ -188,10 +199,6 @@ library LibRainDeploySnapshot {
     function pathForSnapshot(string memory dir, string memory contractName) internal pure returns (string memory) {
         return LibFs.pathForContract(snapshotName(dir, contractName));
     }
-
-    /// The output root `LibFs` writes to, and the only one it can write to:
-    /// `LibFs.pathForContract` hardcodes it.
-    string constant LIB_FS_ROOT = "src/generated";
 
     /// Every file in the FROZEN record: everything inside a release-tag
     /// directory under `root`.

--- a/test/src/lib/LibRainDeploySnapshot.t.sol
+++ b/test/src/lib/LibRainDeploySnapshot.t.sol
@@ -201,6 +201,28 @@ contract LibRainDeploySnapshotTest is Test {
         assertEq(LibRainDeploySnapshot.pathForSnapshot("0_1_7", "Foo"), "src/generated/0_1_7/Foo.sol");
     }
 
+    /// The root the record is WALKED from MUST be the root the writer WRITES
+    /// to. They are two constants — `LIB_FS_ROOT` here, and the one
+    /// `LibFs.pathForContract` hardcodes in a package this repo does not own —
+    /// and a walk of a root nothing writes to returns nothing, which every
+    /// record-anchored assertion then passes on. Silence is the failure mode,
+    /// so it is asserted rather than observed.
+    ///
+    /// Compared through `pathForSnapshot`, which is what a snapshot is written
+    /// through, so the right hand side is the writer's own root rather than a
+    /// third restatement of it. The contract name is arbitrary — the path is
+    /// built by concatenation and names no artifact.
+    function testRecordRootIsTheRootTheWriterWritesTo() external pure {
+        assertEq(
+            LibRainDeploySnapshot.pathForSnapshot("0_1_7", "Foo"),
+            string.concat(LibRainDeploySnapshot.LIB_FS_ROOT, "/0_1_7/Foo.sol")
+        );
+        assertEq(
+            LibRainDeploySnapshot.dirForSnapshot(LibRainDeploySnapshot.CANDIDATE),
+            string.concat(LibRainDeploySnapshot.LIB_FS_ROOT, "/", LibRainDeploySnapshot.CANDIDATE)
+        );
+    }
+
     /// A snapshot MUST land at the path this library says it does, and writing
     /// one over a directory that is already there is the ORDINARY case: the
     /// rolling snapshot is regenerated into the same `candidate/` on every


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/81

## The hazard

The record root was spelled three times: `dirForSnapshot` concatenated the
literal `"src/generated/"`, `LIB_FS_ROOT` restated it, and
`LibFs.pathForContract` hardcodes it a third time in `rain-sol-codegen-0.1.6`,
which is what `pathForSnapshot` writes through.

`frozenSnapshotPaths` returns an empty list for a root that is not there — the
right answer for a repo that has released nothing, and indistinguishable from a
root nothing writes to. So a root that drifted out of step would leave
`testEveryFrozenSnapshotIsReleased` walking an empty tree and passing with no
subject, permanently, while nothing anywhere went red.

## What landed

**`dirForSnapshot` derives from `LIB_FS_ROOT`**, which is moved above it and is
now the only spelling of the root inside this library. The two remaining
spellings are this one and `LibFs`'s own.

**`testRecordRootIsTheRootTheWriterWritesTo`** pins those two against each
other, through `pathForSnapshot` — so the right-hand side is the writer's own
root rather than a third restatement of it. An empty walk now means the record
is empty rather than misaddressed.

## Part (3) of the proposed fix is not here, deliberately

The issue proposed `assertEq(paths.length, released.length)` in
`testEveryFrozenSnapshotIsReleased`, and its own verification block flagged this
part for the fixer. It is worse than the caveat reads: it turns this repo's
suite red immediately.

`RainDeployVerifySnapshotTest is ExampleDeploySuites, RainDeployVerifySnapshot`
inherits `testEveryFrozenSnapshotIsReleased`. `ExampleDeploySuites` declares two
released suites against a real record holding zero files, so the equality is
`0 == 2`. And it cannot be fixed by giving the exemplar a record: the repo
deliberately builds record fixtures under `test/generated` precisely because a
fixture release in the real root is a release every other contract forge runs in
parallel has to fail on.

The deeper reason is that the precedent does not transfer. `NoDeployCandidates`
is a production guard because an empty candidate list is *illegal*. An empty
record is *legal* — it is the state of every deploy repo before its first
release, and of any repo that deployed something before adopting this machinery
and never will have a frozen record for it. A size check red-lines that
permanently with no way to spell the exemption.

Non-vacuity here can only be the root pin: emptiness is a legal state, so what
has to be asserted is that finding nothing *means* nothing is there. That is
what the pin buys, and `testEveryFrozenSnapshotIsReleased` now carries a
docstring saying so and saying why the size guard is not the answer.

The pin also stayed in the library's own test file rather than moving into the
shipped abstract. `LibFs` is imported at a version-pinned path
(`rain-sol-codegen-0.1.6/...`) and every write goes through
`LibRainDeploySnapshot`, so a consumer cannot make the two roots differ — the
invariant is entirely internal to this repo, and shipping the test would give
consumers a red they can neither cause nor fix.

## Mutation evidence

One character changed in `LIB_FS_ROOT` (`src/generated` -> `src/generatedX`),
modelling the drift the issue predicts.

**On `main`, the full suite is green — 215 passed, 0 failed.** The record check
is inert and nothing notices. That is the finding, reproduced.

**On this branch the same mutation is caught:**

```
[FAIL: assertion failed: src/generated/0_1_7/Foo.sol != src/generatedX/0_1_7/Foo.sol]
    testRecordRootIsTheRootTheWriterWritesTo()
[FAIL: assertion failed: src/generatedX/0_1_7 != src/generated/0_1_7]
    testSnapshotPathsAgreeWithTheWriter()
```

Worth noting from the same run: `testEveryFrozenSnapshotIsReleased` **passed**
under the drifted root on both branches. It cannot catch its own vacuity, which
is why the guard has to be the pin.

Unmutated: 216 passed, 0 failed (215 + the new test), `forge fmt --check` clean.

## QA

- **Discriminating tests:** `testRecordRootIsTheRootTheWriterWritesTo` — fails on
  base by construction (the test does not exist on `main`, and the property it
  asserts is unasserted there: every existing `LIB_FS_ROOT` use builds its
  expectation from `LIB_FS_ROOT` itself, and `testSnapshotPathsAgreeWithTheWriter`
  pins `dirForSnapshot` and `pathForSnapshot` against literals but never
  `LIB_FS_ROOT`). Verified by mutation rather than by assertion: the drift that
  this test exists for leaves `main`'s full suite green (215/215) and fails on
  this branch.
- **Mutations applied:**
  - `src/lib/LibRainDeploySnapshot.sol` `LIB_FS_ROOT = "src/generated"` ->
    `"src/generatedX"`, on this branch -> killed by
    `testRecordRootIsTheRootTheWriterWritesTo`
    (`src/generated/0_1_7/Foo.sol != src/generatedX/0_1_7/Foo.sol`) and by
    `testSnapshotPathsAgreeWithTheWriter`
    (`src/generatedX/0_1_7 != src/generated/0_1_7`).
  - the identical mutation on `main` -> **SURVIVED**, full suite 215 passed /
    0 failed. This is the finding reproduced, and the reason the test is worth
    adding.
  - same mutation, both branches -> `testEveryFrozenSnapshotIsReleased`
    **SURVIVED** on each. Recorded because it is the point: the record check
    cannot catch its own vacuity, so the guard has to be the root pin.
  - Harness proven live rather than silently filtering: the mutation runs
    reported `2 tests passed, 2 failed (4 total tests)` under an explicit
    `--match-test`, i.e. named tests actually executed and the counts moved.
- **Oracle:** the writer. The expected root is not a literal transcribed into the
  test — it is whatever `LibFs.pathForContract` (in `rain-sol-codegen-0.1.6`,
  a package this repo does not own) actually produces, reached through
  `pathForSnapshot`, which is what a snapshot is written through. So the test
  cannot be satisfied by editing this repo's literals in lockstep, which is the
  failure mode the issue predicts ("a refactor updates two of the three
  spellings").
- **Category check:** the issue asks for (1) one spelling of the root in this
  library derived from `LIB_FS_ROOT`, (2) a test pinning the walked root to the
  writer's, (3) a non-vacuity assertion on the record-anchored check. (1) and (2)
  are implemented as proposed. (3) is implemented as the pin plus documentation
  rather than as the proposed `assertEq(paths.length, released.length)` — that
  form turns this repo's own suite red (`0 == 2` via
  `RainDeployVerifySnapshotTest`, which inherits the check while
  `ExampleDeploySuites` declares two releases against an empty record), and it
  forbids a legal state. Reasoning is in the section above; flagging it
  explicitly as a departure from the issue's proposed fix, which that issue's own
  verification block referred to the fixer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
