### PR TITLE
docs: use the SPDX identifier for the licence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Use the nix-pinned `forge` for all development.
 
 ## License
 
-DecentraLicense 1.0 (DCL-1.0) — full text in
+DecentraLicense 1.0 (SPDX: `LicenseRef-DCL-1.0`) — full text in
 [`LICENSES/`](LICENSES/LicenseRef-DCL-1.0.txt). Roughly `CAL-1.0`
 ([opensource.org](https://opensource.org/license/cal-1-0)) plus user-data
 disclosure obligations consistent with permissionless-blockchain assumptions.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/69

Audit finding `D3-07` (dimension 3, INFO).

README's License section wrote the licence as `DecentraLicense 1.0 (DCL-1.0)`.
`DCL-1.0` is not a valid SPDX identifier for this licence — the repo's
identifier is `LicenseRef-DCL-1.0` everywhere it is actually load-bearing
(every `src/**` and `test/**` SPDX header, `REUSE.toml`, `foundry.toml`, the
`LICENSE` symlink target) and in CLAUDE.md's own parallel License section.
README was the one place stating a form a consumer could copy into their own
headers, where `reuse lint` would then fail on it.

The expansion "DecentraLicense 1.0" was already correct — the licence file's
own first heading is `# DecentraLicense` — so only the parenthetical changes:

```diff
-DecentraLicense 1.0 (DCL-1.0) — full text in
+DecentraLicense 1.0 (SPDX: `LicenseRef-DCL-1.0`) — full text in
```

`SPDX:` labels it as the identifier rather than an abbreviation, which is the
distinction that was missing — the whole defect was that a bare parenthetical
reads as "here is the short name you may use".

## Verification

- Repo-wide grep for `DCL-1.0` (excluding `dependencies/`, `out/`, `cache/`,
  `.git/`) now returns zero bare occurrences: every remaining hit is
  `LicenseRef-DCL-1.0`. README.md:364 was the only one.
- Adjacent `CAL-1.0` on line 365 is untouched and correct — that IS a valid
  SPDX identifier, for the unrelated licence it compares against.
- New line is 63 characters, inside the wrap the rest of the file uses.
- No behaviour, compile, CI or on-chain surface is touched. Nothing lints
  README prose (`rainix-sol-legal` runs `reuse lint`, which checks SPDX
  headers and `REUSE.toml`), and no test in `test/` asserts on README text —
  which is why the divergence survived in the first place.

## QA
- Discriminating tests: n/a — the diff is one line of README prose. Nothing in
  the repo asserts on README text, and adding a README-prose linter is a
  different change than the one the issue asks for. The issue's own
  verification block establishes the same thing: `reuse lint` covers SPDX
  headers and `REUSE.toml`, not prose, and no test in `test/` reads README.
- Mutations applied: n/a — a docs-only diff has no executable line to mutate.
  The equivalent check for a text change is exhaustiveness, and that was run:
  repo-wide `grep -rn "DCL-1\.0"` excluding `dependencies/`, `out/`, `cache/`,
  `.git/` now returns zero hits that are not `LicenseRef-DCL-1.0` (exit 1, no
  matches). Stated plainly: grep-zero is not mutation coverage, it is proof
  the string is gone.
- Oracle: independent of README. The SPDX spec requires the `LicenseRef-`
  prefix for a licence not on the SPDX list; the licence file's own first
  heading (`LICENSES/LicenseRef-DCL-1.0.txt:1`) is `# DecentraLicense`,
  confirming the expansion; and `REUSE.toml`, `foundry.toml`, the `LICENSE`
  symlink target and every `src/**` / `test/**` SPDX header independently
  spell the identifier as `LicenseRef-DCL-1.0`. README was measured against
  those, not against itself.
- Category check: the issue asks for one thing — README's licence shorthand is
  not the identifier used everywhere else — and gives the exact replacement
  text. Covered exactly. Widened past the single cited line to the whole repo
  by grep to confirm README.md:364 really was the only instance of the
  category, rather than fixing only the example the issue named; it was.
