### PR TITLE
docs: replace dangling Extrospection reference with the codehash mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Approach:
 - Hard guards against deploying to networks where dependencies are missing.
 - Pre-calculated addresses asserted against the creation code before deploying,
   and against the chain after: silent failures fail loudly.
-- Bytecode integrity checks (e.g. via the Rain Extrospection lib) supported
-  post-deploy.
+- Bytecode integrity checks post-deploy: `codehash` is compared against the
+  recorded pin on every network by `RainDeployVerifyChain`, and before every
+  registry access by `LibAddressRegistry` and `LibMigrationRegistry`.
 - An address registry, read at run time rather than compiled into creation code,
   and a post-deploy check that every target network's deployment took the
   address it was supposed to.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/65

The Approach list pointed readers at the Rain Extrospection lib as the example
mechanism for post-deploy bytecode integrity. Nothing in this repo uses it:
`grep -rni extrospection` over the tree hit only that one README line, and
`remappings.txt` / `soldeer.lock` carry exactly two dependencies
(`forge-std`, `rain-sol-codegen`), so the lib is not even available to be used.
The bullet described an integration that does not exist.

Replaced with what the source actually does — `codehash` comparison — naming
the contracts a reader can go read.

## Deviation from the issue's proposed text

The issue proposed `...and before every registry **read** by LibAddressRegistry
and LibMigrationRegistry`. That is accurate for `LibAddressRegistry`, whose only
function is the read `resolve`, but narrower than `LibMigrationRegistry`, which
gates the write `applyMigration` (line 168) as well as the reads `applied`
(122) and `head` (139). The library's own comment is explicit that this is the
point: "Both entry points check ... a read would branch a test on whatever that
code returned, and a write would record a migration somewhere nothing will ever
read it."

Shipping "read" verbatim would have swapped a stale-example inaccuracy for a
too-narrow one, so the wording is `access`, the property both libraries share.
The issue's own verification block used the same wider phrasing ("gate every
registry touch on a codehash pin"); only the proposed-fix line narrowed it.

## Verification

Every call site named in the new text was read at this branch's base
(`86f8d96`) and does what the text says:

- `src/abstract/RainDeployVerifyChain.sol:88-100` — `checkDeployedOnNetwork`
  reverts `NotDeployedOnNetwork` on empty code, then compares
  `derived.deployedAddress.codehash` against `derived.bytecodeHash`.
- `src/lib/LibAddressRegistry.sol:45-52` — `resolve` compares the registry's
  `codehash` against `ADDRESS_REGISTRY_DEPLOYED_CODEHASH` before the `get` call.
- `src/lib/LibMigrationRegistry.sol:93-100` — `checkCodeHash` compares against
  `MIGRATION_REGISTRY_DEPLOYED_CODEHASH`; called from all three entry points.

Post-change `grep -rni extrospection` over the tree (excluding `.git`,
`dependencies`, `out`) returns nothing.

Documentation only — no Solidity changed.

## QA
- Discriminating tests: n/a — no test asserts README prose, and adding one would
  pin wording rather than behaviour. The discriminating check is
  `git grep -ni extrospection <rev> -- README.md src script test foundry.toml
  remappings.txt soldeer.lock`, which fails on base (`86f8d96:README.md:36`) and
  returns no hits at this head.
- Mutations applied: n/a — docs-only diff, no executable line to mutate. Repo
  gates run: `reuse lint` exit 0 (71/71 files compliant); pre-commit
  (denofmt, no-consumer-prettier) passed on the commit.
- Oracle: the Solidity source, read independently of the README. Each contract
  the new text names was opened and confirmed to compare `codehash`:
  `RainDeployVerifyChain.checkDeployedOnNetwork` (src/abstract/
  RainDeployVerifyChain.sol:88-100), `LibAddressRegistry.resolve`
  (src/lib/LibAddressRegistry.sol:45-52), and `LibMigrationRegistry.checkCodeHash`
  (src/lib/LibMigrationRegistry.sol:93-100), whose three callers were enumerated
  by grep to establish that "access" and not "read" is the correct word.
- Category check: issue #65 asks one thing — remove the dangling Extrospection
  reference and describe the real mechanism. Covered. The grep that found the
  finding was re-run tree-wide post-change and is clean, so the category
  (dangling references to this absent lib) is exhausted, not just the cited line.
