### PR TITLE
test: name the real suite keys in two shared-creation-code comments

### DIFF
--- a/test/src/abstract/RainDeploySuitesBase.t.sol
+++ b/test/src/abstract/RainDeploySuitesBase.t.sol
@@ -62,9 +62,10 @@ contract RainDeploySuitesBaseTest is Test {
     }
 
     /// Two suites that record the SAME creation code MUST still be selectable
-    /// apart. `0_0_2` and the candidate are the same bytes at the same address,
-    /// so the key is the only thing that distinguishes them — and it has to,
-    /// because they are separately deployable records.
+    /// apart. `address-registry-0-0-1` and `address-registry-candidate` are the
+    /// same bytes at the same address, so the key is the only thing that
+    /// distinguishes them — and it has to, because they are separately
+    /// deployable records.
     function testSuitesSharingCreationCodeSelectApart() external view {
         DeploySuite memory released = sSuites.externalSuiteByName("address-registry-0-0-1");
         DeploySuite memory candidate = sSuites.externalSuiteByName("address-registry-candidate");

--- a/test/src/abstract/RainDeployVerifySnapshot.t.sol
+++ b/test/src/abstract/RainDeployVerifySnapshot.t.sol
@@ -387,8 +387,9 @@ contract RainDeployVerifySnapshotTest is ExampleDeploySuites, RainDeployVerifySn
 
     /// Two suites that record the SAME creation code MUST both derive, which
     /// is the ordinary state of a repo between a release and the next source
-    /// change. `0_0_2` and the candidate are the same bytes and therefore the
-    /// same address, and the whole set still passes.
+    /// change. `address-registry-0-0-1` and `address-registry-candidate` are
+    /// the same bytes and therefore the same address, and the whole set still
+    /// passes.
     function testSuitesSharingCreationCodeAllDerive() external {
         DeploySuite[] memory suites = allSuites();
         assertEq(suites.length, 4);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/74

Two NatSpec comments described the suite they document by the key `0_0_2`, which no fixture declares. `ExampleDeploySuites` declares `address-registry-0-0-1`, `second-address`, `address-registry-candidate` and `second-address-candidate`; the only `0_0_2` strings in the repo are in `test/src/lib/LibRainDeploySnapshot.t.sol`, an unrelated snapshot-generator fixture tree that neither of these tests touches. So a reader searching for `0_0_2` to find what the assertion covers found nothing, and the comments had stopped describing current behaviour.

Both now name the two entries the tests actually select:

- `test/src/abstract/RainDeploySuitesBase.t.sol` — above `testSuitesSharingCreationCodeSelectApart`, which selects `"address-registry-0-0-1"` and `"address-registry-candidate"` by name.
- `test/src/abstract/RainDeployVerifySnapshot.t.sol` — above `testSuitesSharingCreationCodeAllDerive`, which asserts over `suites[0]` and `suites[2]`; in the fixture's declaration order those are the same two keys.

Comment text only — no assertion, generated artifact, production bytecode or deploy path reads these strings. Wording is unchanged apart from the two key names; the surrounding lines are rewrapped only because the longer keys no longer fit the existing column width.

## QA
- Discriminating tests: n/a — the diff is NatSpec comment text only, so no test can distinguish base from head. The two tests these comments document were run to confirm the keys the comments now name are the ones under test, and both pass at this head: `testSuitesSharingCreationCodeSelectApart` and `testSuitesSharingCreationCodeAllDerive` (`forge test --match-test "testSuitesSharingCreationCode"`, 2 passed / 0 failed). `forge fmt --check` is clean.
- Mutations applied: n/a — a comment-only diff has no executable line to mutate; the changed bytes are stripped by the compiler and reach no bytecode, assertion or generated artifact.
- Oracle: `test/abstract/ExampleDeploySuites.sol`, which declares the suite keys, independent of any comment — `address-registry-0-0-1` (line 44), `second-address` (53), `address-registry-candidate` (74), `second-address-candidate` (86). `testSuitesSharingCreationCodeSelectApart` selects the first and third by literal name; `testSuitesSharingCreationCodeAllDerive` asserts over `suites[0]`/`suites[2]`, which are those same two entries in declaration order. No `0_0_2` key exists; the repo's only `0_0_2` strings are version-directory and generated-suite fixtures in `test/src/lib/LibRainDeploySnapshot.t.sol`, which neither test touches, so the old text was not cross-referencing a live entity.
- Category check: the issue asks that the stale key be renamed to the declared key in both comments — `test/src/abstract/RainDeploySuitesBase.t.sol:65` and `test/src/abstract/RainDeployVerifySnapshot.t.sol:390`; both are covered, and `grep -rn 0_0_2 src/ test/` now returns only the unrelated `LibRainDeploySnapshot.t.sol` fixture lines the issue's verification block excludes.
