### PR TITLE
docs: `@param` tags for `UnexpectedDeployedAddress`

### DIFF
--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -22,7 +22,15 @@ library LibRainDeploy {
     /// Thrown when a dependency is missing on a network before deployment.
     error MissingDependency(string network, address dependency);
 
-    /// Thrown when the deployed address does not match the expected address.
+    /// Thrown when an address does not match the address the deploy expects.
+    /// Raised at two distinct points, and nothing is deployed at the first of
+    /// them: before any fork, when the address the creation code derives is not
+    /// the expected one, and after broadcasting, when the address deployed to
+    /// is not the expected one.
+    /// @param expected The `expectedAddress` the caller passed to
+    /// `deployToNetworks` or `deployAndBroadcast`, at both sites.
+    /// @param actual The address the creation code derives, before any fork, or
+    /// the address actually deployed to, after broadcasting.
     error UnexpectedDeployedAddress(address expected, address actual);
 
     /// Thrown when the deployed code hash does not match the expected code hash.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/70

`error UnexpectedDeployedAddress(address expected, address actual)` in
`src/lib/LibRainDeploy.sol` carried a single prose line and zero `@param` tags,
while every other error-declaring file in `src/` documents its error params with
`@param`. This adds the tags.

## The two revert sites

The error is raised at two points, both inside `deployToNetworks` (and so
reachable through `deployAndBroadcast`, which delegates to it):

- `src/lib/LibRainDeploy.sol:399` — before any fork, when
  `zoltuAddress(creationCode)` derives an address other than `expectedAddress`.
  **Nothing is deployed at this point.**
- `src/lib/LibRainDeploy.sol:431` — after `vm.stopBroadcast()`, when the address
  actually deployed to is not `expectedAddress`.

`actual` therefore means something different at each site, which is what the
missing `@param` tags left undocumented.

## Two corrections to the issue's proposed text

The issue's proposed fix is not applied verbatim. Its own collapsed verification
block identifies both problems, and the diff resolves them:

1. **The summary line is corrected, not preserved.** The proposed fix keeps
   `Thrown when the deployed address does not match the expected address.` The
   verification block states this line "is factually wrong for that site" —
   nothing is deployed when the pre-fork check fires, so there is no deployed
   address to mismatch. Adding `@param` tags underneath a false summary would
   have left the documented defect in place. The summary now covers both sites
   and says outright that nothing is deployed at the first.

2. **`expected` is described from the signature, not from a sibling file.** The
   proposed `The address the suite records.` is flagged in the verification
   block as "imported phrasing from `RainDeployVerifySnapshot`" — here `expected`
   is the caller-supplied `expectedAddress` argument, not necessarily
   suite-sourced. Confirmed against both revert sites: each passes the
   `expectedAddress` parameter through unmodified.

## QA

- Discriminating tests: n/a — the diff changes only NatSpec comment text. There
  is no runtime behaviour a test could discriminate on, and Solidity has no
  assertion surface over `@param` tags. The obligation this change has is the
  inverse one — that it changes NOTHING — which is what the bytecode equality
  below establishes.
- Mutations applied: n/a — docs-only diff. Comment text has no line whose
  mutation produces a distinguishable program: `cbor_metadata = false` and
  `bytecode_hash = "none"` in `foundry.toml` strip metadata, so comments are not
  reachable from the compiled output at all. Verified, not assumed — see below.
- Oracle: the source itself, read independently of the issue. Both revert sites
  were read in full (`src/lib/LibRainDeploy.sol:399` and `:431`) and the
  argument each passes as `expected` traced back to the `expectedAddress`
  parameter of `deployToNetworks`; `deployAndBroadcast` was read and confirmed to
  delegate rather than raise the error itself. This is what caught both defects
  in the issue's proposed text, which its own verification block had flagged.
- Category check: the issue asks for (a) `@param` tags on both parameters and
  (b) the two distinct meanings of `actual` documented. Both covered. The
  summary-line correction is not extra scope — the issue's verification block
  records that line as "factually wrong for that site", so it is part of the
  documented defect.

## Verification

Comment-only change — no bytecode, address or code-hash pin can move. Verified
rather than assumed: `AddressRegistry` and `MigrationRegistry` were built at
this branch and at `main`, and the sha256 of both `bytecode.object` and
`deployedBytecode.object` is identical across all four pairs.

The repo's own pin authority agrees: `RegistryDeploySnapshotTest`,
`RainDeployVerifySnapshotTest` and `GeneratedSnapshotShapeTest` are 27/27 green,
including `testSnapshotMatchesSource`, which asserts each recorded
`CREATION_CODE` equals `type(X).creationCode`.

Full suite: 168 passed, 47 failed — every one of the 47 failing on a missing
`*_RPC_URL` env var (no `.env` in this environment), which is the fork-test
requirement CLAUDE.md documents. Zero failures with any other cause; checked by
grepping every `[FAIL]` line, not by sampling.

`forge fmt --check` and `forge build` are clean, pre-commit hooks pass, and all
new comment lines sit within the file's 80-column comment convention.
