### PR TITLE
Refuse a leading zero on a release-version component

### DIFF
--- a/src/lib/LibRainDeploySnapshot.sol
+++ b/src/lib/LibRainDeploySnapshot.sol
@@ -87,8 +87,8 @@ library LibRainDeploySnapshot {
         return tagForVersion(vm.parseTomlString(vm.readFile("foundry.toml"), ".package.version"));
     }
 
-    /// Whether `subject` is three non-empty runs of digits joined by exactly
-    /// two `separator`s.
+    /// Whether `subject` is three numbers joined by exactly two `separator`s,
+    /// each written without a leading zero.
     ///
     /// The ONE definition of the release-version shape. It is asked with `.`
     /// for a version out of `foundry.toml` and with `_` for the directory that
@@ -115,6 +115,16 @@ library LibRainDeploySnapshot {
                 separators++;
                 digitsInComponent = 0;
             } else if (char >= "0" && char <= "9") {
+                // A component is one number, so it has one spelling. `01` and
+                // `1` are the same release and would freeze to two directories,
+                // neither of which `SnapshotAlreadyFrozen` sees as the other,
+                // and which `recordPrecedes` cannot order because they compare
+                // equal as versions. `i` is at least 1 wherever
+                // `digitsInComponent == 1`, because that digit was read at an
+                // earlier index.
+                if (digitsInComponent == 1 && subjectBytes[i - 1] == "0") {
+                    return false;
+                }
                 digitsInComponent++;
             } else {
                 return false;

--- a/test/src/lib/LibRainDeploySnapshot.t.sol
+++ b/test/src/lib/LibRainDeploySnapshot.t.sol
@@ -99,6 +99,25 @@ contract LibRainDeploySnapshotTest is Test {
         assertFalse(LibRainDeploySnapshot.isTag("collision-guard"));
     }
 
+    /// A component has ONE spelling. A padded component is the same release as
+    /// its unpadded form: it freezes to a second directory the immutability
+    /// check does not recognise as the first, and the two compare equal as
+    /// versions so nothing can order them either.
+    function testIsStrictTripleRefusesLeadingZeros() external pure {
+        assertFalse(LibRainDeploySnapshot.isStrictTriple("0.01.5", "."));
+        assertFalse(LibRainDeploySnapshot.isStrictTriple("01.1.5", "."));
+        assertFalse(LibRainDeploySnapshot.isStrictTriple("0.1.05", "."));
+        assertFalse(LibRainDeploySnapshot.isStrictTriple("00.0.0", "."));
+        assertFalse(LibRainDeploySnapshot.isTag("0_01_5"));
+
+        // The boundary: a single zero IS the number zero, and `0.0.0` is a real
+        // version.
+        assertTrue(LibRainDeploySnapshot.isStrictTriple("0.0.0", "."));
+        assertTrue(LibRainDeploySnapshot.isStrictTriple("0.10.0", "."));
+        assertTrue(LibRainDeploySnapshot.isStrictTriple("10.0.100", "."));
+        assertTrue(LibRainDeploySnapshot.isTag("0_0_0"));
+    }
+
     /// EVERY version a freeze accepts MUST produce a directory the record
     /// recognises as a release. A version that could be frozen to a directory
     /// the record then ignores is exactly the orphan snapshot
@@ -179,6 +198,16 @@ contract LibRainDeploySnapshotTest is Test {
     /// to a directory the append-only gate ignores forever.
     function testTagForVersionRefusesNonStrict() external {
         string[9] memory bad = ["0.1.7-rc1", "0.1", "0.1.7.1", "", "a.b.c", ".1.7", "0..7", "0.1.", "0.1.7 "];
+        for (uint256 i = 0; i < bad.length; i++) {
+            vm.expectRevert(abi.encodeWithSelector(UnreleasableVersion.selector, bad[i]));
+            this.externalTagForVersion(bad[i]);
+        }
+    }
+
+    /// The refusal MUST be reachable through the release path, naming the
+    /// version, rather than only through the predicate.
+    function testTagForVersionRefusesLeadingZeros() external {
+        string[3] memory bad = ["0.01.5", "01.1.5", "0.1.05"];
         for (uint256 i = 0; i < bad.length; i++) {
             vm.expectRevert(abi.encodeWithSelector(UnreleasableVersion.selector, bad[i]));
             this.externalTagForVersion(bad[i]);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/51

`isStrictTriple` accepted any non-empty run of digits per component, so `0.01.5`
was as strict a triple as `0.1.5`. That made one release have two spellings, and
every guard built on the predicate reads them as two different releases:

- `freeze` refuses a re-cut on `vm.exists(dirForSnapshot(tag))`. With `0_1_5`
  frozen, bumping `[package].version` to `0.01.5` names a directory that does not
  exist, so the same release is frozen a second time under a second name and
  `SnapshotAlreadyFrozen` never fires.
- `recordPrecedes` reads both tags through `vm.parseUint`, so `0_01_5` and
  `0_1_5` compare EQUAL as versions and fall through to the byte-for-byte path
  tiebreak — ordered by the accident of a zero character rather than by release.
- Both are then declared as separate released suites and both are demanded live
  on every network by the chain group.

The version is also the soldeer `[package].version`, where `0.01.5` is not a
version any consumer can resolve.

The file states its own job as "the ONE definition of the release-version shape",
whose purpose is that two spellings cannot drift apart. Admitting two spellings
of one version is that same defect one step down, so the fix belongs in the
predicate rather than in a second check beside it.

## The fix

A component is one number, so it gets one spelling: refuse a leading zero on a
multi-digit component. The check fires on the second digit of a component whose
first digit was `0`, which is the only position a leading zero can occupy —
`digitsInComponent` resets at every separator, so each component is checked
independently, and `i` is at least 1 wherever `digitsInComponent == 1` because
that digit was read at an earlier index.

A single `0` stays legal. It IS the number zero, `0.0.0` is a real version, and
it is already pinned by `testIsTagAcceptsWhatAFreezeCanWrite`.

Because `isTag` is the same predicate asked with `_`, the directory side moves
with the version side — which is the property that made one predicate the right
place for this.

The doc comment stated the old rule ("three non-empty runs of digits") and now
states the current one.

## Tests

- `testIsStrictTripleRefusesLeadingZeros` — the padded spellings are refused at
  every component position (`0.01.5`, `01.1.5`, `0.1.05`, `00.0.0`), the tag form
  `0_01_5` with them, and the boundary is pinned on the accept side: `0.0.0`,
  `0.10.0`, `10.0.100`, `0_0_0`. Zeros inside and at the end of a component are
  what separate this from a rule that would refuse `0.10.0`.
- `testTagForVersionRefusesLeadingZeros` — the refusal is reachable through the
  release path, reverting `UnreleasableVersion` naming the version, not only
  through the predicate.

The existing fuzz `testEveryFreezableVersionIsATagTheRecordFinds` keeps passing:
`vm.toString` of a `uint256` never emits a leading zero.

Nothing in `src/generated/` is affected — it holds only `candidate/`, and no
existing tag has a padded component, so no directory that the record counts today
stops being counted.

## QA
- Discriminating tests: `testIsStrictTripleRefusesLeadingZeros`, `testTagForVersionRefusesLeadingZeros` — each fails on base (verified by reverting the guard to the pre-fix source, mutant 1 below: predicate test `FAIL: assertion failed`, tagFor test `FAIL: next call did not revert as expected`; both `PASS` unmutated, 22 tests observed to run in every case)
- Mutations applied: `src/lib/LibRainDeploySnapshot.sol:125` → (1) guard deleted entirely, i.e. the exact pre-fix code → killed by BOTH new tests; (2) `digitsInComponent == 1` → `digitsInComponent >= 1` (rejects a zero at any position, so `10.0.100` is refused) → killed by `testIsStrictTripleRefusesLeadingZeros`; (3) `subjectBytes[i - 1] == "0"` → `char == "0"` (inspects the current digit instead of the component's first, so `0.10.0` is refused while `0.01.5` is accepted) → killed by BOTH new tests. No surviving mutants.
- Oracle: a version component is a NUMBER, so `01` and `1` denote the same release and a release must have one spelling — derived from semver and from the repo's own use of the value (`recordPrecedes` reads tags through `vm.parseUint`, which maps both spellings to the same integer; `[package].version` is the soldeer version, where `0.01.5` resolves for nobody). The accept/reject set is fixed by that rule, not by reading the predicate: zeros INSIDE and at the END of a component (`0.10.0`, `10.0.100`) are the same number either way and must stay accepted, which is what separates this from a rule that refuses any zero.
- Category check: issue asks (a) refuse a leading zero on a multi-digit component while keeping a lone `0` legal, (b) pin the predicate directly, (c) pin the refusal as reachable through the release path naming the version; covered (a) by the `:125` guard, (b) by `testIsStrictTripleRefusesLeadingZeros` (all three component positions, plus `00.0.0` and the tag form `0_01_5`, plus the accept-side boundary `0.0.0`/`0.10.0`/`10.0.100`/`0_0_0`), (c) by `testTagForVersionRefusesLeadingZeros` asserting `UnreleasableVersion` carries the offending version. Full suite green with fork RPCs configured: 217 passed, 0 failed, 17 suites.
