### PR TITLE
fix(package): stop publishing .audit/, and say what the package actually ships

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,4 +1,5 @@
 .DS_Store
+.audit
 .coderabbitai.yaml
 .git
 .github

--- a/README.md
+++ b/README.md
@@ -321,12 +321,13 @@ forge soldeer install rain-deploy~<version>
 ```
 
 **You also need `forge-std` 1.16.1**, remapped as `forge-std-1.16.1/`. The
-published package deliberately ships only `src/` and `script/` — no
-`remappings.txt`, no `soldeer.lock`, no `dependencies/` — so a consumer resolves
-`forge-std` itself. The requirement is transitive rather than incidental: the
-deployed contract imports nothing outside this package, but every abstract a
-consumer inherits pulls forge-std in — `Script` via `RainDeployBroadcast`,
-`Test` via `RainDeployVerifyBase`, and `Vm` via `LibRainDeploy` beneath both:
+published package ships `src/`, `script/` and the licence and README files — no
+`test/`, no `foundry.toml`, no `remappings.txt`, no `soldeer.lock`, no
+`dependencies/` — so a consumer resolves `forge-std` itself. The requirement is
+transitive rather than incidental: the deployed contract imports nothing outside
+this package, but every abstract a consumer inherits pulls forge-std in —
+`Script` via `RainDeployBroadcast`, `Test` via `RainDeployVerifyBase`, and `Vm`
+via `LibRainDeploy` beneath both:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/68

`README.md:324` claimed the published package "deliberately ships only `src/`
and `script/`". It does not, and the issue's own enumeration of what else ships
was itself incomplete.

## What actually ships

Not derived by reading `.soldeerignore` — taken from a real package build:

```sh
nix develop -c forge soldeer push rain-deploy~0.1.5 --dry-run --skip-warnings
unzip -Z1 rain.zip
```

On `main` (`86f8d96`) the zip contains, outside `src/` and `script/`:

```
.audit/
.audit/runs.jsonl
.audit/scope.json
LICENSE
LICENSES/
LICENSES/LicenseRef-DCL-1.0.txt
README.md
REUSE.toml
```

`.soldeerignore` uses gitignore syntax, so its `/audit` entry is anchored at the
root and matches `audit/` only — `.audit/` is a different path and was never
covered. That directory is audit-skill bookkeeping (a run stamp and a file
scope); it was added by `86f8d96`, the commit after the last `.soldeerignore`
edit, so nothing ever brought it under the exclusion list. Every other dotpath
at the root — `.git`, `.github`, `.gitignore`, `.coderabbitai.yaml`,
`.soldeerignore`, `.vscode`, `.pre-commit-config.yaml` — is excluded explicitly,
and soldeer's own `--skip-warnings` flag exists precisely because dotfiles are
otherwise pushed. `.audit/` shipping is an omission, not a decision.

## The changes

**`.soldeerignore`** — add `.audit`, alongside the dotpaths it belongs with.
This is the fix at the source. Consumers have no use for this repo's audit
bookkeeping, and it is the same class of internal tooling state as `audit/`,
`CLAUDE.md` and `.github/`, all already excluded.

**`README.md`** — the wording from the issue, which is true once `.audit/` is
gone, and which adds the two exclusions the rest of the repo actually leans on.
`CLAUDE.md:253` and `src/abstract/RegistryDeploySuites.sol:34` both justify
putting the `RainDeploy*` abstracts in `src/` rather than `test/` on the grounds
that `.soldeerignore` excludes `test/`, which the README never said.

The alternative — leave `.soldeerignore` alone and write "ships `src/`,
`script/`, the licence and README files and `.audit/`" — was rejected. It would
have documented the defect into the contract rather than fixed it, which is the
same shape of mistake as the sentence being replaced.

## Verification

Re-running the same dry-run on this branch, the zip contains outside `src/` and
`script/`:

```
LICENSE
LICENSES/
LICENSES/LicenseRef-DCL-1.0.txt
README.md
REUSE.toml
```

Exactly what the new sentence says, and nothing else. `reuse lint` passes —
`REUSE.toml` still annotates `.audit/**/`, which is correct, as the directory
remains in the repo and only stops being published.

## QA

- Discriminating tests: n/a — the diff is one `.soldeerignore` line and one
  README paragraph. There is no Solidity or Rust in it and no test harness in
  this repo that can observe package contents (see the gap below). The
  discriminating check is the `soldeer push --dry-run` above, run on base and on
  this branch: base emits `.audit/runs.jsonl` and `.audit/scope.json` into the
  zip, this branch does not. That is a real before/after on the artifact the
  change is about, not a re-read of the file I edited.
- Mutations applied: n/a — no executable code in the diff to mutate. The
  equivalent falsification was done against the ignore file's semantics rather
  than a test: `/audit` was checked to be root-anchored gitignore syntax that
  cannot match `.audit`, which is why the entry had to be added rather than the
  existing one relied on, and the dry-run confirms it.
- Oracle: the zip `forge soldeer push --dry-run` produces, which is what soldeer
  actually uploads. Deliberately not `.soldeerignore` read by eye — reading the
  ignore file is what produced the original wrong claim, and it is also what
  produced the issue's own incomplete list, which missed `.audit/`.
- Category check: the issue asks for one thing — the `README.md:324` package
  contents claim made accurate — and gives proposed replacement text. Covered,
  with the text as proposed. The `.soldeerignore` line is not extra scope: the
  proposed text is false on `main` because `.audit/` ships, so the sentence
  cannot be landed as written without it. The issue's list of what ships
  (`README.md`, `LICENSE`, `LICENSES/`, `REUSE.toml`) is corrected here, not
  contradicted.

## Known remaining gap, not addressed here

Nothing in the repo or CI asserts package contents, which is why this drifted
silently in the first place. A guard would be a `soldeer push --dry-run` in CI
diffed against a committed manifest. That is separate work and is not in this
PR.
