### PR TITLE
test: drop duplicate MockAddressRevertingFactory import

### DIFF
--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -9,7 +9,6 @@ import {AddressRegistry, ADDRESS_REGISTRY_ROOT} from "../../../src/concrete/Addr
 import {MockAddressRevertingFactory} from "../../concrete/MockAddressRevertingFactory.sol";
 import {MockResolvedOwner} from "../../concrete/MockResolvedOwner.sol";
 import {MockDirtyWordOwner} from "../../concrete/MockDirtyWordOwner.sol";
-import {MockAddressRevertingFactory} from "../../concrete/MockAddressRevertingFactory.sol";
 import {MockDeployable} from "../../concrete/MockDeployable.sol";
 import {MockDeployableV2} from "../../concrete/MockDeployableV2.sol";
 import {MockReverter} from "../../concrete/MockReverter.sol";


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/71

`test/src/lib/LibRainDeploy.t.sol` imported `MockAddressRevertingFactory` from `../../concrete/MockAddressRevertingFactory.sol` at line 9 and again, byte-identically, at line 12. This deletes the line-12 copy. One line, nothing else in the diff.

The symbol is still used — `new MockAddressRevertingFactory()` at what are now lines 400 and 1142 — so this removes a redundant duplicate line, not a live import. solc tolerates a repeated identical declaration, so nothing about compilation, runtime or behaviour changes. The whole cost was a reader having to diff two lines to conclude they are the same, which is also why it survived: nothing fails, so nothing points at it.

## Category, not just the cited line

The issue names one file and one symbol. The rule behind it is one import per symbol per file, so I checked that property across the repo rather than only the two cited lines: over every `*.sol` tracked in git, flattening each import's braced symbol list (multi-line import blocks included, so a symbol split across lines is still counted) and looking for any symbol imported twice in the same file returns exactly one hit — this file, this symbol. There is nothing else in the category, so the one-line fix is the whole fix.

## Why nothing caught it

`nix develop -c forge fmt --check` exits 0 on the tree with the duplicate present, so the formatter neither flags nor removes it; `slither.config.json` is not configured for it; solc is silent by design. None of the three CI matrix tasks would have failed on this. This PR does not add a guard — that is scope beyond the issue — but the gap is worth stating rather than leaving implied.

## QA

- **Discriminating tests:** n/a, and deliberately. This diff deletes a redundant duplicate declaration; it has no reachable behaviour to assert, so a test asserting it would assert nothing. The compiler is the only oracle that can discriminate here, and it is exercised under "Mutations applied" below. Existing coverage is unchanged: `LibRainDeployTest` still compiles and still exercises `MockAddressRevertingFactory` at both call sites.
- **Mutations applied:** `test/src/lib/LibRainDeploy.t.sol` line 9 — delete the *surviving* import as well, so the file has zero imports of `MockAddressRevertingFactory` against two usages -> killed by `nix develop -c forge build`, which fails with `Error (7920): Identifier not found or not unique.` pointing at line 400. That is the mutation that matters for this change: it proves the line the PR keeps is load-bearing and the line the PR deletes is not, which is exactly the claim "this was a duplicate, not a dead import". The inverse direction is already established and is why the issue exists — restoring the duplicate leaves the build, the formatter and slither all green, so no mutant on the deleted line can be killed by anything.
- **Oracle:** solc symbol resolution, independent of this repo's own test assertions — the compiler decides whether `MockAddressRevertingFactory` resolves at lines 400 and 1142, and it is not consulted about which of two identical import lines provided it. The duplicate's own cited location came from the issue and was re-read against source before editing.
- **Category check:** issue asks for exactly one thing — delete the duplicate import at line 12. Covered, plus the repo-wide scan above confirming this is the only symbol imported twice in any file, so no sibling instance is left behind.

**Test runs.** `nix develop -c forge fmt --check` exits 0. Full `nix develop -c forge test` with the five documented public RPC endpoints in `.env`: 202 passed across 17 suites, 16 suites fully green. The 13 failures were confined to `LibRainDeploy.t.sol`, and every one of the 26 `[FAIL]` lines is an HTTP 429 public-RPC rate limit (`Public RPC Rate Limit Hit` / `over rate limit`) from the shared free endpoints — zero assertion failures, and no failure mentions the import, the mock, or anything this diff touches.

Re-running that one suite with `--threads 1` takes it to **53 passed / 1 failed of 54**, the single remaining failure again a 429 from `arb1.arbitrum.io`. Failures fall 13 -> 1 purely by lowering RPC concurrency, with no source change between the two runs, which is what identifies rate limiting rather than the diff as the cause. CI runs with real RPC secrets and is the verdict that counts.
