### PR TITLE
ci: dispatchable explorer verification for a deployment that already exists

### DIFF
--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -1,0 +1,50 @@
+name: Manual sol verify
+# Explorer source verification for a registry that is ALREADY on chain, run by
+# hand.
+#
+# `manual-sol-artifacts.yaml` submits source only for what its own run
+# broadcast, and the broadcast is idempotent: a rerun against networks that
+# already hold the code broadcasts nothing, so there is nothing for `--verify`
+# to submit and the run is green having verified nothing. A deploy that landed
+# and then failed verification — a bad explorer key, a rate limit, an explorer
+# that was down — is repaired here rather than by re-dispatching the deploy.
+#
+# Deliberately `workflow_dispatch` only, like the deploy. Unlike the deploy this
+# never broadcasts and never reads `DEPLOYMENT_KEY`: `forge verify-contract`
+# talks to the explorer API and nothing else, so it is safe to re-run and is
+# already a no-op ("already verified") against an explorer that has the source.
+on:
+  workflow_dispatch:
+    inputs:
+      contract:
+        type: string
+        required: true
+        description: |
+          Artifact path of the contract to submit, `path:Contract`. Paired with
+          `address` on the `manual verification command:` line `script/Deploy.sol`
+          prints for every network, whether it deployed there or skipped it, so
+          a run of the deploy is where both values come from.
+      address:
+        type: string
+        required: true
+        description: |
+          The deployed address. One value for every network, because the Zoltu
+          factory derives one address from the creation code.
+      networks:
+        type: string
+        required: true
+        default: arbitrum base base-sepolia flare polygon
+        description: |
+          Which explorers to submit to. FOUNDRY's chain names, not the
+          `[rpc_endpoints]` aliases: `base-sepolia` is a chain name and
+          `base_sepolia` is rejected outright. The default is
+          `LibRainDeploy.supportedNetworks()` spelled that way, i.e. every
+          network the deploy broadcasts to, so it has to move when that does.
+jobs:
+  verify:
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-verify.yaml@main
+    with:
+      contract: ${{ inputs.contract }}
+      address: ${{ inputs.address }}
+      networks: ${{ inputs.networks }}
+    secrets: inherit


### PR DESCRIPTION
Adds `Manual sol verify`: a `workflow_dispatch` that submits the source of a registry that is already on chain to every supported explorer.

Blocked by https://github.com/rainlanguage/rainix/pull/312 — this is the caller; the reusable it pins at `@main` lands there first.

## Why this exists separately from the deploy

`manual-sol-artifacts.yaml` submits source only for what its own run broadcast, and the broadcast is idempotent by construction: `LibRainDeploy.deployToNetworks` skips any network that already has code at the expected address. So once a deploy has landed, re-dispatching it broadcasts nothing, `--verify` has nothing to submit, and the run is green having verified nothing — a false success, not a repair.

That is the state this repo was in. Both registries broadcast to all five networks on 2026-08-15 and then died on the first explorer with `Invalid API Key (#err2)`: https://github.com/rainlanguage/rain.deploy/actions/runs/31874483065 and https://github.com/rainlanguage/rain.deploy/actions/runs/31874687768. base, base_sepolia, flare and polygon were never attempted at all.

Confirmed the re-dispatch route is a dead end rather than assuming it: `script/Deploy.sol:Deploy` run against all five networks now logs ` - Code already exists at expected address, skipping deployment` on every one and records no transactions.

## Shape

`contract` and `address` are dispatch inputs rather than a `suite` choice with the values baked in, because the addresses and artifact paths already have exactly one home — the candidate declarations in `RegistryDeploySuites` and the generated snapshots they read — and a second copy in a workflow is a pin that can go stale silently. The deploy prints the pair it wants on its `manual verification command:` line for every network, whether it deployed there or skipped it, so the values come from a run rather than from memory.

`networks` defaults to `LibRainDeploy.supportedNetworks()` in foundry's spelling. Foundry's chain names are not the `[rpc_endpoints]` aliases: `base-sepolia` is a chain name and `base_sepolia` is rejected outright by `forge verify-contract --chain`, which is worth knowing because the `manual verification command:` line the deploy prints uses the alias and is therefore not directly runnable for that one network.

It never broadcasts and never reads `DEPLOYMENT_KEY`.

## QA
- Discriminating tests: n/a — a workflow caller has no unit-testable surface. Exercised end to end instead, against the real explorers, at https://github.com/rainlanguage/rain.deploy/actions/runs/31949208775: the same `uses:`/`with:`/`secrets: inherit` call this file makes, over both registries and all five networks. Result: `AddressRegistry` and `MigrationRegistry` verified on arbiscan, basescan, sepolia.basescan, flare-explorer and polygonscan.
- Mutations applied: n/a — the diff is one workflow file with no branch a mutation could survive. The input shape was instead falsified against the alternative: a `suite` choice was tried first and rejected because it can only work by copying the deployed addresses into the workflow, giving this repo's most load-bearing constants a second home.
- Oracle: the explorers, not the run. Verified is read back from the explorer itself — https://basescan.org/address/0x25aC2b82915f191dbE64e65BAeDDD68b97b68fe1, https://polygonscan.com/address/0x6E3aE74aDCd6CF28A1b2F685D5E709ffE44D429D and `https://flare-explorer.flare.network/api?module=contract&action=getsourcecode` — and the `--watch` responses quoted in the run are the explorer's own words.
- Category check: covers the category rather than the incident. Nothing here is specific to `Invalid API Key`; it is the repair path for any contract that is on chain and unverified, including a network added after a deploy, an explorer that was down, and a rate-limited submission.
