### PR TITLE
Move the release version under foundry's [external] section

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -3,8 +3,8 @@ name: Package Release
 # carries deployed concretes (`AddressRegistry`, `MigrationRegistry`) whose
 # address + codehash consumers pin, which is exactly the shape
 # rainix-tag-release exists for and exactly the shape rainix-autopublish's
-# merge-driven, next-version lifecycle is wrong for: autopublish bumps
-# [package].version on every merge while the frozen deploy tag only advances at
+# merge-driven, next-version lifecycle is wrong for: autopublish bumps the
+# release version on every merge while the frozen deploy tag only advances at
 # deploy time.
 #
 # The tag names the version; rainix-tag-release runs `cutRelease()`, which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ relocated.
 - **Broadcasting is key custody and real money.** Nothing automatic ever
   broadcasts: `Manual sol artifacts` is `workflow_dispatch` only, and no merge,
   tag or schedule may be given a path to it.
-- **A `sol-v*` tag is the sole release trigger.** `[package].version` in
-  `foundry.toml` is the version of the LAST Soldeer publish, not a next-version
-  slot, so an ordinary PR does not bump it.
+- **A `sol-v*` tag is the sole release trigger.**
+  `[external.package].version` in `foundry.toml` is the version of the LAST
+  Soldeer publish, not a next-version slot, so an ordinary PR does not bump it.
 - **`src/generated/<tag>/` is an append-only record.** `cutRelease()` writes a
   tag directory once. A cut tag can never be un-cut and consumers pin what it
   holds, so a frozen record is never edited, renamed or deleted.

--- a/README.md
+++ b/README.md
@@ -388,11 +388,11 @@ Three separate steps, in this order. Nothing automatic ever broadcasts.
 
 This is a deploy repo: it carries deployed concretes whose addresses and
 codehashes consumers pin, so releases are **manual `sol-v*` tags**, not merges.
-`[package].version` is the version of the LAST Soldeer publish, and only a
-release moves it. A release cut under this lifecycle also names the frozen
-`src/generated/<tag>/` record `cutRelease()` wrote for it. Every version
-published under the previous merge-driven lifecycle predates that record and has
-none, so `src/generated/` holds no directory for it; those versions stay
+`[external.package].version` is the version of the LAST Soldeer publish, and
+only a release moves it. A release cut under this lifecycle also names the
+frozen `src/generated/<tag>/` record `cutRelease()` wrote for it. Every version
+published under the previous merge-driven lifecycle predates that record and
+has none, so `src/generated/` holds no directory for it; those versions stay
 published, and consumers pin exact versions and are unaffected.
 
 ## Install

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,8 @@
-[package]
+# Release metadata, not foundry config: `LibRainDeploySnapshot.deployTag` reads
+# `version` as the release being built, and `rainix-tag-release` rewrites it
+# from the tag. `[external.*]` is the section foundry reserves for another
+# tool's config: it never merges it into a profile and never warns about it.
+[external.package]
 name = "rain-deploy"
 # Deploy repo: this is the version of the LAST Soldeer publish, not a
 # next-version slot. A normal PR does not bump it; only a `sol-v*` tag release

--- a/src/lib/LibRainDeploySnapshot.sol
+++ b/src/lib/LibRainDeploySnapshot.sol
@@ -12,10 +12,10 @@ import {GENERATED_DIR, LibFs} from "rain-sol-codegen-0.1.36/src/lib/LibFs.sol";
 import {DeploySuite} from "../abstract/RainDeploySuitesBase.sol";
 import {LibRainDeploy} from "./LibRainDeploy.sol";
 
-/// Thrown when `[package].version` is not strict `X.Y.Z`. A version like
-/// `0.1.7-rc1` maps to the directory `0_1_7-rc1`, which the append-only gate's
-/// tag predicate ignores forever — an orphan snapshot nothing protects. Refused
-/// rather than frozen.
+/// Thrown when `[external.package].version` is not strict `X.Y.Z`. A version
+/// like `0.1.7-rc1` maps to the directory `0_1_7-rc1`, which the append-only
+/// gate's tag predicate ignores forever — an orphan snapshot nothing protects.
+/// Refused rather than frozen.
 /// @param version The version read from `foundry.toml`.
 error UnreleasableVersion(string version);
 
@@ -54,8 +54,8 @@ error NonMonotonicRelease(string tag, string newestFrozenTag);
 /// frozen. Release machinery, not code generation.
 ///
 /// It lives here rather than in `rain-sol-codegen` deliberately. Emitting a
-/// Solidity constant is codegen; reading `[package].version`, deciding a
-/// release directory and making that directory immutable is the deploy
+/// Solidity constant is codegen; reading `[external.package].version`, deciding
+/// a release directory and making that directory immutable is the deploy
 /// lifecycle, which is this repo's subject. `LibCodeGen` still emits every
 /// constant — that split is the point, not an oversight.
 ///
@@ -79,8 +79,9 @@ error NonMonotonicRelease(string tag, string newestFrozenTag);
 /// that freezes without regenerating, so "freeze, then regenerate" has nowhere
 /// to be written.
 ///
-/// @dev The consuming repo's `foundry.toml` must grant read access to itself so
-/// `deployTag` can read the release version from it:
+/// @dev The consuming repo's `foundry.toml` must declare the release version
+/// at `[external.package].version` and grant read access to itself so
+/// `deployTag` can read it:
 /// `fs_permissions = [{ access = "read", path = "./foundry.toml" }, ...]`
 /// alongside read-write access to `./src`.
 library LibRainDeploySnapshot {
@@ -90,15 +91,15 @@ library LibRainDeploySnapshot {
     /// looking.
     string constant CANDIDATE = "candidate";
 
-    /// The canonical release tag: `foundry.toml` `[package].version` with dots
-    /// converted to underscores (`0.1.7` -> `0_1_7`) for the Solidity directory
-    /// form. The single definition of the tag form — the version in
+    /// The canonical release tag: `foundry.toml` `[external.package].version`
+    /// with dots converted to underscores (`0.1.7` -> `0_1_7`) for the Solidity
+    /// directory form. The single definition of the tag form — the version in
     /// `foundry.toml` is the one source of truth for which release is being
     /// built, so every path derives from it rather than restating it.
     /// @param vm The Vm instance for file operations.
     /// @return The tag.
     function deployTag(Vm vm) internal view returns (string memory) {
-        return tagForVersion(vm.parseTomlString(vm.readFile("foundry.toml"), ".package.version"));
+        return tagForVersion(vm.parseTomlString(vm.readFile("foundry.toml"), ".external.package.version"));
     }
 
     /// Whether `subject` is three numbers joined by exactly two `separator`s,

--- a/test/src/lib/LibRainDeploySnapshot.t.sol
+++ b/test/src/lib/LibRainDeploySnapshot.t.sol
@@ -271,8 +271,25 @@ contract LibRainDeploySnapshotTest is Test {
     function testDeployTagUsesTheGuardedConversion() external view {
         assertEq(
             LibRainDeploySnapshot.deployTag(vm),
-            LibRainDeploySnapshot.tagForVersion(vm.parseTomlString(vm.readFile("foundry.toml"), ".package.version"))
+            LibRainDeploySnapshot.tagForVersion(
+                vm.parseTomlString(vm.readFile("foundry.toml"), ".external.package.version")
+            )
         );
+    }
+
+    /// PROPERTY: the release version lives at `[external.package].version`, and
+    /// `foundry.toml` carries no top-level `[package]` section.
+    ///
+    /// `external` is the only unreserved root section foundry ignores; every
+    /// other one it reads as a profile and warns about on every invocation,
+    /// and `forge config --fix` rewrites into `[profile.*]`. Both halves are
+    /// asserted because the release read and the silence are separate: a repo
+    /// that gained a second copy of the version under `[package]` would read
+    /// correctly and warn anyway.
+    function testReleaseVersionLivesUnderTheExternalSection() external view {
+        string memory config = vm.readFile("foundry.toml");
+        assertTrue(vm.keyExistsToml(config, ".external.package.version"));
+        assertFalse(vm.keyExistsToml(config, ".package"));
     }
 
     /// Snapshot paths MUST agree with `LibFs`, which is what writes them.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/133

`foundry.toml` opened with a bare `[package]`. foundry reads any root section it
does not reserve as a profile, so every `forge` invocation printed:

```
Warning: Found unknown config section in foundry.toml: [package]
This notation for profiles has been deprecated and may result in the profile not being registered in future versions.
Please use [profile.package] instead or run `forge config --fix`.
```

The section is now `[external.package]` and `LibRainDeploySnapshot.deployTag`
reads `.external.package.version`. `forge config` on this branch prints no such
warning. Same change, same section, as `rain.sol.codegen`
https://github.com/rainlanguage/rain.sol.codegen/pull/143.

## Verified at source, at this repo's pinned toolchain

The flake here resolves `forge 1.7.2-nightly` at `43923a4e`, and at that SHA:

- `Config::is_standalone_section` returns true for `EXTERNAL_SECTION`
  (`crates/config/src/lib.rs:718-722`). `WarningsProvider::collect_warnings`
  emits `UnknownSection` for exactly the root keys that predicate rejects
  (`crates/config/src/providers/warnings.rs`), and `forge config --fix` filters
  by the same predicate (`crates/config/src/fix.rs:146`). `external` is NOT in
  `STANDALONE_SECTIONS`, so nothing under it is merged into a profile either —
  which is why `name`/`version` under it cannot raise `UnknownKey` the way they
  would under `[profile.package]`.
- soldeer never reads the section. That SHA's `Cargo.lock` pins
  `soldeer-core 0.10.1`, whose `crates/core/src/config.rs` contains the string
  `package` **zero** times. `rainix-tag-release` publishes with
  `forge soldeer push "$SOLDEER_PACKAGE~$VERSION"` — name and version off the
  command line, not out of the file.

## The release path is unchanged, measured rather than assumed

This is a tag-released repo, so the one automated writer of that line is
`rainix-tag-release`'s bump —
`sed -i -E "0,/^version[[:space:]]*=.*/s//version = \"${VERSION}\"/" foundry.toml`
followed by a `grep -qxE` that fails the release loudly if it matched nothing.
Run against both files with `VERSION=0.1.6`:

| `foundry.toml` | `sed` result | `grep -qxE` |
| --- | --- | --- |
| `ed91bfa` (main) | one line changed, `version = "0.1.5"` -> `version = "0.1.6"` | match |
| this branch | one line changed, `version = "0.1.5"` -> `version = "0.1.6"` | match |

It anchors on the first line beginning `version` with no section awareness, and
that line is still first and unindented. `foundry.toml` is also in
`.soldeerignore`, so the published package's bytes never contained it.

## Ramification: what a consuming repo must declare

`LibRainDeploySnapshot` is published and `deployTag(vm)` reads the CONSUMING
repo's `foundry.toml`, so a repo that calls it must carry its release version at
`[external.package].version`. Consumers pin exact versions, so nothing moves for
anyone until they bump, and this repo's own version only advances on a `sol-v*`
tag — this PR publishes nothing. The library's `@dev` note now names that key
next to the `fs_permissions` entry it already required.

## Adversarial mutation pass

Committed before mutating. Every run is the WHOLE suite with no filter, because
a filter is the trap this repo sets: `LibAddressRegistryDeploy`'s address and
codehash pins fail under any change to compiler input, so a filter that includes
them reports KILLED for everything and measures nothing. They stay green in all
five runs below, which is what shows the suite discriminating rather than
collapsing.

| # | Mutation | Suite ran | Non-RPC failures | Killed by |
| --- | --- | --- | --- | --- |
| M0 | none (baseline) | 311 tests, 260 passed / 51 failed | 0 | — |
| M1 | `foundry.toml`: `[external.package]` -> `[package]` | 311 tests, 251 / 60 | 9 | `testReleaseVersionLivesUnderTheExternalSection` + the 8 `deployTag` readers |
| M2 | reader path -> `.package.version` | 311 tests, 252 / 59 | 8 | `testDeployTagUsesTheGuardedConversion` + 7 `freeze` tests |
| M3 | reader path -> `.external.package.name` | 311 tests, 252 / 59 | 8 | the same 8, via `UnreleasableVersion("rain-deploy")` |
| M4 | keep the working read, append a SECOND bare `[package]` | 311 tests, 259 / 52 | 1 | `testReleaseVersionLivesUnderTheExternalSection` ONLY |
| M5 | `foundry.toml`: `[external.package]` -> `[profile.package]` | 311 tests, 251 / 60 | 9 | the same 9 as M1 |

5 killed, 0 survived. The 51 failures in every row are the unchanged
`*_RPC_URL not found` baseline.

M4 is what earns the new test. The read still resolves, the release path is
intact and every pre-existing test passes; the only thing that fails is
`assertFalse(vm.keyExistsToml(config, ".package"))`. Without that half of the
assertion, a repo could grow the warning back with a green suite. M5 is the
mirror: `[profile.package]` silences the `.package` half and fails the
`.external.package.version` half, so both assertions are load-bearing and the
test pins `external` specifically rather than "not `[package]`".

## Checks

- `nix develop -c forge config`: the `[package]` warning is present on `ed91bfa`
  and absent on this branch; the only line left on stderr is the unrelated
  nightly-build notice, which `ed91bfa` prints too.
- `nix develop -c forge test`: 260 passed / 51 failed / 311 total, against
  259 / 51 / 310 on `ed91bfa`. The +1 is the new test; no other count moves, and
  all 51 are `*_RPC_URL not found`.
- `nix develop -c forge fmt --check`: exit 0.

## QA
- Discriminating tests: `testReleaseVersionLivesUnderTheExternalSection` in
  `test/src/lib/LibRainDeploySnapshot.t.sol` — fails on base, verified by
  running it against `ed91bfa`'s `foundry.toml` as mutant M1 above
  (`[external.package]` -> `[package]`, `[FAIL: assertion failed]`).
  `testDeployTagUsesTheGuardedConversion` and the seven `freeze` tests fail on
  base too once the reader moves (M2/M3). The test's subject is `deployTag`'s
  source of truth, so it mirrors `src/lib/LibRainDeploySnapshot.sol`; it reads
  `foundry.toml` the way `testSupportedNetworksAreFullyConfigured` already reads
  it for `[rpc_endpoints]`/`[etherscan]` — config, not prose.
- Mutations applied: `foundry.toml:5` `[external.package]` -> `[package]` ->
  `testReleaseVersionLivesUnderTheExternalSection` + 8 `deployTag` readers;
  `foundry.toml` gains a second bare `[package]` alongside the working read ->
  `testReleaseVersionLivesUnderTheExternalSection` alone;
  `foundry.toml:5` -> `[profile.package]` -> the same 9;
  `src/lib/LibRainDeploySnapshot.sol:101` `".external.package.version"` ->
  `".package.version"` -> `testDeployTagUsesTheGuardedConversion` + 7 `freeze`
  tests; the same line -> `".external.package.name"` -> the same 8 via
  `UnreleasableVersion("rain-deploy")`. 5 applied, 5 killed, 0 survived; full
  table with per-run suite counts above.
- Oracle: foundry's and soldeer's own source at the toolchain this repo pins —
  `is_standalone_section`/`STANDALONE_SECTIONS` and `fix.rs` at `43923a4e`,
  `soldeer-core 0.10.1` `crates/core/src/config.rs` — plus `rainix-tag-release`'s
  bump `sed`/`grep` run against the real file. Not the warning text, and not
  this repo's own code.
- Category check: the issue asks for (a) `[package]` -> `[external.package]`
  with `version` left unindented and first, (b) a comment saying the section is
  another tool's metadata rather than foundry config, (c) prose naming
  `[package].version` fixed in the same pass, and (d) the version reader proven
  byte-identical before and after. Covered a, b, c, d. (d) is the
  `rainix-tag-release` bump rather than `rainix-static soldeer-gate`: this repo
  is tag-released, `package-release.yaml` calls `rainix-tag-release.yaml`, and
  `soldeer-gate` runs only in `rainix-autopublish.yaml`, which this repo never
  invokes. Both anchor identically on the first `^version[[:space:]]*=` line.
  Beyond the issue: this repo has a reader the issue's precedent repo does not —
  `LibRainDeploySnapshot.deployTag` really parses the TOML — so the path moves
  with the section, which is the coordination the issue's closing note
  sequences.
