### PR TITLE
Re-run the whole-repo mutation campaign and re-ledger it

### DIFF
--- a/audit/mutation-test-scans.json
+++ b/audit/mutation-test-scans.json
@@ -18,5 +18,28 @@
       "confirmed": 3,
       "filed": ["#16", "#17", "#18"]
     }
+  },
+  {
+    "timestamp": "2026-08-18T13:31:09Z",
+    "commit": "ed91bfa5161fa94c5180d57a54e2a4341ba8e876",
+    "publishedTag": "sol-v0.1.5",
+    "commitsAheadOfTag": 211,
+    "scope": "whole repo",
+    "tool": "adversarial-mutation-test",
+    "skillVersion": "0.33.0",
+    "summary": {
+      "units": 15,
+      "behaviours": 264,
+      "killedByExistingTests": 234,
+      "gapsFilled": 7,
+      "equivalentMutants": 7,
+      "unkillableDefensiveGuards": 3,
+      "notExecutedBySuite": 11,
+      "nonTerminating": 2,
+      "candidates": 1,
+      "confirmed": 1,
+      "filed": [],
+      "alreadyFiled": ["#135"]
+    }
   }
 ]

--- a/test/concrete/MissingDependencyDeploy.sol
+++ b/test/concrete/MissingDependencyDeploy.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {RainDeployBroadcast} from "../../src/abstract/RainDeployBroadcast.sol";
+import {DeployCandidate, DeploySuite, RainDeploySuitesBase} from "../../src/abstract/RainDeploySuitesBase.sol";
+import {LibRainDeploy} from "../../src/lib/LibRainDeploy.sol";
+import {MockDeployable} from "./MockDeployable.sol";
+
+/// @dev The address the candidate declares must already hold code, and which
+/// holds none on any network.
+address constant ABSENT_DEPENDENCY = address(0xdeadbee5);
+
+/// @title MissingDependencyDeploy
+/// @notice A deploy script whose candidate declares a dependency that is on no
+/// network, so a broadcast that carries the declared list to
+/// `deployToNetworks` refuses before it deploys anything and one that carries
+/// an empty list deploys.
+///
+/// The suite is `MockDeployable`, which is on no supported network, so the
+/// broadcast takes the deploying branch — the already-deployed branch skips the
+/// dependency check by design and would say nothing about the list.
+///
+/// One network, so the refusal names a chain that is the whole target set
+/// rather than the first of five. Keyed `second-address-candidate` for the
+/// reason `StalePinDeploy` gives.
+contract MissingDependencyDeploy is RainDeployBroadcast {
+    /// @inheritdoc RainDeployBroadcast
+    function deployNetworks() internal pure override returns (string[] memory networks) {
+        networks = new string[](1);
+        networks[0] = LibRainDeploy.ARBITRUM_ONE;
+    }
+
+    /// @inheritdoc RainDeploySuitesBase
+    function releasedSuites() internal pure override returns (DeploySuite[] memory suites) {
+        suites = new DeploySuite[](0);
+    }
+
+    /// @inheritdoc RainDeploySuitesBase
+    function candidateSuites() internal pure override returns (DeployCandidate[] memory candidates) {
+        address[] memory dependencies = new address[](1);
+        dependencies[0] = ABSENT_DEPENDENCY;
+
+        candidates = new DeployCandidate[](1);
+        candidates[0] = DeployCandidate({
+            snapshot: DeploySuite({
+                suite: "second-address-candidate",
+                creationCode: type(MockDeployable).creationCode,
+                storedDeployedAddress: LibRainDeploy.zoltuAddress(type(MockDeployable).creationCode),
+                storedBytecodeHash: keccak256(type(MockDeployable).runtimeCode),
+                storedRuntimeCode: type(MockDeployable).runtimeCode,
+                artifactPath: "test/concrete/MockDeployable.sol:MockDeployable",
+                dependencies: dependencies
+            }),
+            sourceCreationCode: type(MockDeployable).creationCode
+        });
+    }
+}

--- a/test/concrete/MockChainDependentOwner.sol
+++ b/test/concrete/MockChainDependentOwner.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title MockChainDependentOwner
+/// @notice Answers the read `MockResolvedOwner` answers with one address on one
+/// chain and another everywhere else.
+///
+/// This is the deployment the network matrix exists to find: one contract, at
+/// one deterministic address, holding a different resolved value on a chain
+/// nobody looked at. A deployment that answers the same thing everywhere cannot
+/// tell a matrix that forked every network from one that forked the first.
+contract MockChainDependentOwner {
+    /// The address answered on `iChainId`.
+    address public immutable iOwnerOnChain;
+
+    /// The address answered on every other chain.
+    address public immutable iOwnerElsewhere;
+
+    /// The chain `iOwnerOnChain` is answered on.
+    uint256 public immutable iChainId;
+
+    /// @param ownerOnChain The address to answer on `chainId`.
+    /// @param ownerElsewhere The address to answer everywhere else.
+    /// @param chainId The chain `ownerOnChain` is answered on.
+    constructor(address ownerOnChain, address ownerElsewhere, uint256 chainId) {
+        iOwnerOnChain = ownerOnChain;
+        iOwnerElsewhere = ownerElsewhere;
+        iChainId = chainId;
+    }
+
+    /// The selector `MockResolvedOwner` answers.
+    /// @return The address for the chain this is called on.
+    function iOwner() external view returns (address) {
+        return block.chainid == iChainId ? iOwnerOnChain : iOwnerElsewhere;
+    }
+}

--- a/test/concrete/MockRevertingAnswerOwner.sol
+++ b/test/concrete/MockRevertingAnswerOwner.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title MockRevertingAnswerOwner
+/// @notice Answers the read `MockResolvedOwner` answers by REVERTING with
+/// exactly the bytes a successful answer would have carried.
+///
+/// Nothing about the returned bytes distinguishes it from a real answer — same
+/// length, same word, same address — so only whether the call SUCCEEDED
+/// separates the two. A revert carrying an ABI-encoded address is ordinary: a
+/// custom error whose one argument is an address is that shape, and so is any
+/// `require` that bubbles a callee's return data.
+contract MockRevertingAnswerOwner {
+    /// The bytes this contract reverts every read with.
+    bytes internal sAnswer;
+
+    /// @param answer The bytes to revert with.
+    constructor(bytes memory answer) {
+        sAnswer = answer;
+    }
+
+    /// The selector `MockResolvedOwner` answers, reverting with `sAnswer` as
+    /// the whole of the revert data.
+    function iOwner() external view {
+        bytes memory answer = sAnswer;
+        assembly ("memory-safe") {
+            revert(add(answer, 0x20), mload(answer))
+        }
+    }
+}

--- a/test/concrete/StalePinDeploy.sol
+++ b/test/concrete/StalePinDeploy.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {RainDeployBroadcast} from "../../src/abstract/RainDeployBroadcast.sol";
+import {DeployCandidate, DeploySuite, RainDeploySuitesBase} from "../../src/abstract/RainDeploySuitesBase.sol";
+import {MockDeployableV2} from "./MockDeployableV2.sol";
+
+/// @dev The address the candidate records, which its own creation code does not
+/// derive.
+address constant STALE_PIN_ADDRESS = address(0xdead);
+
+/// @title StalePinDeploy
+/// @notice A deploy script whose candidate records an address its creation code
+/// does not derive: the snapshot whose pins went stale while its recorded bytes
+/// stayed current.
+///
+/// The source anchor has nothing to say about it — the recorded creation code IS
+/// the source — so this reaches `deployAndBroadcast` carrying a pin that
+/// describes nothing, which is the state the pre-fork address comparison exists
+/// for.
+///
+/// Keyed `second-address-candidate` so it answers to the `DEPLOYMENT_SUITE` the
+/// broadcast test has already set: that variable is process-wide and forge runs
+/// tests concurrently, so every write to it stays inside the one test that owns
+/// it.
+contract StalePinDeploy is RainDeployBroadcast {
+    /// @inheritdoc RainDeploySuitesBase
+    function releasedSuites() internal pure override returns (DeploySuite[] memory suites) {
+        suites = new DeploySuite[](0);
+    }
+
+    /// @inheritdoc RainDeploySuitesBase
+    function candidateSuites() internal pure override returns (DeployCandidate[] memory candidates) {
+        candidates = new DeployCandidate[](1);
+        candidates[0] = DeployCandidate({
+            snapshot: DeploySuite({
+                suite: "second-address-candidate",
+                creationCode: type(MockDeployableV2).creationCode,
+                storedDeployedAddress: STALE_PIN_ADDRESS,
+                storedBytecodeHash: keccak256(type(MockDeployableV2).runtimeCode),
+                storedRuntimeCode: type(MockDeployableV2).runtimeCode,
+                artifactPath: "test/concrete/MockDeployableV2.sol:MockDeployableV2",
+                dependencies: new address[](0)
+            }),
+            sourceCreationCode: type(MockDeployableV2).creationCode
+        });
+    }
+}

--- a/test/src/abstract/RainDeployBroadcast.t.sol
+++ b/test/src/abstract/RainDeployBroadcast.t.sol
@@ -9,6 +9,8 @@ import {LibRainDeploy} from "../../../src/lib/LibRainDeploy.sol";
 import {ExampleDeploy} from "../../concrete/ExampleDeploy.sol";
 import {ExampleDeploySingleNetwork} from "../../concrete/ExampleDeploySingleNetwork.sol";
 import {SourceMismatchDeploy} from "../../concrete/SourceMismatchDeploy.sol";
+import {StalePinDeploy, STALE_PIN_ADDRESS} from "../../concrete/StalePinDeploy.sol";
+import {MissingDependencyDeploy, ABSENT_DEPENDENCY} from "../../concrete/MissingDependencyDeploy.sol";
 import {MockDeployable} from "../../concrete/MockDeployable.sol";
 import {MockDeployableV2} from "../../concrete/MockDeployableV2.sol";
 
@@ -107,6 +109,15 @@ contract RainDeployBroadcastTest is Test {
     /// Here rather than in a test of its own for the reason the first two are
     /// here: this leg has to SET `DEPLOYMENT_SUITE`, and a second test doing
     /// that is a second test racing the first over one process-global variable.
+    ///
+    /// ## Carrying the suite's own pins and its own dependencies
+    ///
+    /// Two further legs drive declarations whose selected suite differs from the
+    /// one above in exactly one field: a recorded address its creation code does
+    /// not derive, and a dependency that is on no network. Both answer to the
+    /// `DEPLOYMENT_SUITE` this test has already set, so neither adds a writer of
+    /// it, and both fail where a `run()` that derived the pins or dropped the
+    /// list would not.
     function testRunSelectsTheSuiteFromTheEnvBeforeTheKeyNeverDefaultsAndBroadcastsIt() external {
         // `DEPLOYMENT_SUITE` has to be ABSENT and no cheatcode makes it so, so
         // the precondition is asserted: a value set outside this test reports
@@ -194,6 +205,47 @@ contract RainDeployBroadcastTest is Test {
         // VALUE of that function; nothing until here asserted that `run()` is
         // what consults it.
         assertEq(block.chainid, ARBITRUM_ONE_CHAIN_ID);
+
+        // ## The pins it carries are the ones the suite RECORDS
+        //
+        // `deployToNetworks` compares the recorded address against the address
+        // the creation code derives before it forks anything, and that guard is
+        // worth exactly nothing if `run()` hands it a value derived here: a
+        // comparison of a value against itself passes on every suite, stale
+        // pins included, and the deploy lands wherever the code happens to go
+        // rather than where the repo's constants say. The suite above records
+        // pins that are correct, so it cannot tell the two apart; this one
+        // records an address its own creation code does not derive, and the
+        // refusal naming both is the whole of the difference.
+        //
+        // It answers to the same `DEPLOYMENT_SUITE` already set, so this leg
+        // adds no second writer of a process-wide variable.
+        StalePinDeploy stale = new StalePinDeploy();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibRainDeploy.UnexpectedDeployedAddress.selector,
+                STALE_PIN_ADDRESS,
+                LibRainDeploy.zoltuAddress(type(MockDeployableV2).creationCode)
+            )
+        );
+        stale.run();
+
+        // ## And so is the dependency list
+        //
+        // A suite's dependencies are the addresses that MUST already hold code
+        // on a network before it is broadcast there — a constructor that bakes
+        // in a beacon, a fallback that delegatecalls a facet — so a `run()` that
+        // dropped them broadcasts a deployment that is born broken, on every
+        // chain the dispatch reached, at an address `CREATE2` makes permanent.
+        // Every suite above declares none, so none of them can tell a list that
+        // was carried from a list that was replaced with an empty one.
+        MissingDependencyDeploy dependent = new MissingDependencyDeploy();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibRainDeploy.MissingDependency.selector, LibRainDeploy.ARBITRUM_ONE, ABSENT_DEPENDENCY
+            )
+        );
+        dependent.run();
     }
 
     /// The broadcast MUST refuse a candidate that is not the contract this repo

--- a/test/src/abstract/RainDeployVerifySnapshot.t.sol
+++ b/test/src/abstract/RainDeployVerifySnapshot.t.sol
@@ -471,6 +471,86 @@ contract RainDeployVerifySnapshotTest is ExampleDeploySuites, RainDeployVerifySn
         this.externalCheckInternallyConsistent(suite);
     }
 
+    /// The record is matched on the address a released suite's creation code
+    /// DERIVES, never on the address that suite RECORDS.
+    ///
+    /// The two are the same in a consistent set, which is what makes this worth
+    /// stating: a suite whose recorded address has gone stale still deployed
+    /// what its creation code deploys, so it still declares that release — and
+    /// the stale field is `checkInternallyConsistent`'s to catch, with an error
+    /// that names it. Matching on the recorded field instead reports a declared
+    /// release as one nobody declared, and sends the reader to
+    /// `releasedSuites()` to add an entry that is already there.
+    ///
+    /// The suite here is the record's own release with that one field broken,
+    /// so the derivation is the only thing left that can match it.
+    function testFrozenSnapshotMatchesTheDerivationNotTheRecordedAddress() external view {
+        DeploySuite[] memory released = new DeploySuite[](1);
+        released[0] = consistentSuite();
+        released[0].storedDeployedAddress = address(0xdead);
+
+        // It really is the record's release, and it really does record
+        // something else.
+        assertEq(LibRainDeploy.zoltuAddress(released[0].creationCode), ADDRESS_REGISTRY_DEPLOYED_ADDRESS);
+        assertNotEq(released[0].storedDeployedAddress, ADDRESS_REGISTRY_DEPLOYED_ADDRESS);
+
+        this.externalCheckFrozenSnapshotsReleased(recordOfTheGeneratedSnapshot(), released);
+    }
+
+    /// The inherited internal-consistency check MUST reach EVERY declared
+    /// suite.
+    ///
+    /// Every negative case above drives `checkInternallyConsistent` with one
+    /// suite handed to it, so all of them pass on a check that only ever looked
+    /// at the first — and a repo declares one suite until the day it declares
+    /// several, which is the day a snapshot regenerated for one contract and
+    /// not the other appears. The suite broken here is not the first, so a loop
+    /// that stopped there would find nothing to fail on.
+    ///
+    /// Broken through the factory rather than by editing a field, because the
+    /// declaration this contract inherits is the passing case for the inherited
+    /// tests and cannot be broken in place. The mock is
+    /// `testZoltuDerivationMismatchReverts`'s, keyed on the creation code of the
+    /// suite being reached rather than of the first one.
+    function testSnapshotInternallyConsistentReachesEverySuite() external {
+        DeploySuite[] memory suites = allSuites();
+        assertEq(suites[1].suite, "second-address");
+        assertNotEq(keccak256(suites[0].creationCode), keccak256(suites[1].creationCode));
+
+        vm.mockCall(
+            LibRainDeploy.ZOLTU_FACTORY, suites[1].creationCode, abi.encodePacked(bytes20(LibRainDeploy.ZOLTU_FACTORY))
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ZoltuDerivationMismatch.selector,
+                "second-address",
+                suites[1].storedDeployedAddress,
+                LibRainDeploy.ZOLTU_FACTORY
+            )
+        );
+        this.testSnapshotInternallyConsistent();
+    }
+
+    /// The derivation MUST clear the derived address's NONCE, not only its
+    /// code.
+    ///
+    /// `CREATE2` collides on a non-zero nonce exactly as it does on non-empty
+    /// code, and the nonce is the half that leaves nothing to see: an account
+    /// with a nonce and no code reads as empty everywhere else, so a derivation
+    /// that cleared only the code would report a deployment failure for a
+    /// creation code that deploys perfectly well. The Zoltu factory is
+    /// permissionless, so whether anything has ever transacted from the address
+    /// a suite derives is nobody's to control.
+    function testDerivationClearsTheDerivedNonce() external {
+        DeploySuite memory suite = consistentSuite();
+        vm.setNonce(suite.storedDeployedAddress, 1);
+        assertEq(vm.getNonce(suite.storedDeployedAddress), 1);
+        assertEq(suite.storedDeployedAddress.code.length, 0);
+
+        this.externalCheckInternallyConsistent(suite);
+    }
+
     /// The derivation MUST leave nothing behind. A local deploy that survived
     /// would be compared against itself by the chain-anchored group, and every
     /// network would pass whether or not anything is deployed there.

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -10,6 +10,7 @@ import {MockAddressRevertingFactory} from "../../concrete/MockAddressRevertingFa
 import {MockResolvedOwner} from "../../concrete/MockResolvedOwner.sol";
 import {MockDirtyWordOwner} from "../../concrete/MockDirtyWordOwner.sol";
 import {MockRawAnswerOwner} from "../../concrete/MockRawAnswerOwner.sol";
+import {MockRevertingAnswerOwner} from "../../concrete/MockRevertingAnswerOwner.sol";
 import {MockDeployable} from "../../concrete/MockDeployable.sol";
 import {MockDeployableV2} from "../../concrete/MockDeployableV2.sol";
 import {MockReverter} from "../../concrete/MockReverter.sol";
@@ -1007,6 +1008,34 @@ contract LibRainDeployTest is Test {
             )
         );
         this.externalCheckResolvedAddresses("test_network", address(consumer), readCalls, expected(account));
+    }
+
+    /// A read that REVERTS carrying exactly the bytes a successful answer would
+    /// have carried MUST be refused.
+    ///
+    /// Nothing in the payload separates the two: same length, same word, same
+    /// address, and it is the address the check is looking for. Only whether
+    /// the call SUCCEEDED does — which is why the success flag is part of the
+    /// condition rather than left to the length check, and this is the one case
+    /// where the length check has nothing to say. It is not a contrived
+    /// payload: a custom error with one address argument is exactly this shape,
+    /// and so is any revert that bubbles a callee's return data.
+    ///
+    /// The reverting read above carries EMPTY data, so it fails the length
+    /// check and says nothing about the success flag.
+    function testCheckResolvedAddressesRevertingAddressAnswerReverts(address account) external {
+        MockRevertingAnswerOwner target = new MockRevertingAnswerOwner(abi.encode(account));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibRainDeploy.ResolvedAddressReadFailed.selector,
+                "test_network",
+                address(target),
+                uint256(0),
+                abi.encode(account)
+            )
+        );
+        this.externalCheckResolvedAddresses("test_network", address(target), ownerReadCalls(), expected(account));
     }
 
     /// A read that answers with one word whose upper 96 bits are dirty has not

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -11,6 +11,7 @@ import {MockResolvedOwner} from "../../concrete/MockResolvedOwner.sol";
 import {MockDirtyWordOwner} from "../../concrete/MockDirtyWordOwner.sol";
 import {MockRawAnswerOwner} from "../../concrete/MockRawAnswerOwner.sol";
 import {MockRevertingAnswerOwner} from "../../concrete/MockRevertingAnswerOwner.sol";
+import {MockChainDependentOwner} from "../../concrete/MockChainDependentOwner.sol";
 import {MockDeployable} from "../../concrete/MockDeployable.sol";
 import {MockDeployableV2} from "../../concrete/MockDeployableV2.sol";
 import {MockReverter} from "../../concrete/MockReverter.sol";
@@ -1263,6 +1264,42 @@ contract LibRainDeployTest is Test {
             )
         );
         this.externalCheckResolvedAddressesOnNetworks(networks, address(consumer), ownerReadCalls(), expected(wrong));
+    }
+
+    /// `checkResolvedAddressesOnNetworks` MUST advance past the first network.
+    ///
+    /// The passing case above is a deployment that answers the same thing
+    /// everywhere, which a loop that only ever forked the first network passes
+    /// just as happily — and the mismatch case above is one network, so it
+    /// cannot tell them apart either. What separates them is a target that
+    /// answers differently on a LATER network, which is exactly the deployment
+    /// this matrix exists for: one chain of five holding a value nobody looked
+    /// at.
+    ///
+    /// The first network is the one the target agrees on, so nothing fails
+    /// before the loop has to advance, and the failure names the SECOND network
+    /// rather than a fixed one.
+    function testCheckResolvedAddressesOnNetworksReachesEveryNetwork() external {
+        address account = address(0xf00);
+        address wrong = address(0xba4);
+        MockChainDependentOwner target = new MockChainDependentOwner(account, wrong, ARBITRUM_ONE_CHAIN_ID);
+        vm.makePersistent(address(target));
+
+        string[] memory networks = new string[](2);
+        networks[0] = LibRainDeploy.ARBITRUM_ONE;
+        networks[1] = LibRainDeploy.BASE;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibRainDeploy.UnexpectedResolvedAddress.selector,
+                LibRainDeploy.BASE,
+                address(target),
+                uint256(0),
+                account,
+                wrong
+            )
+        );
+        this.externalCheckResolvedAddressesOnNetworks(networks, address(target), ownerReadCalls(), expected(account));
     }
 
     /// `deployToNetworks` MUST deploy when every dependency has code on the


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.deploy/issues/64

The ledger described one library at a commit 211 behind HEAD. This runs the
campaign over everything the repo now compiles and writes the second entry.

## Scope and harness

Whole repo at `ed91bfa`, 15 units, **264 mutants**. Every source file under
`src/` and `script/` with a body of its own; `script/Deploy.sol` is an empty
contract and has none.

The suite command is `nix develop -c forge test` against **five local anvil
chains**, one per configured network, each with the chain id the real network
uses and the Zoltu factory at its canonical address, and each with one block
mined before that code is set so the factory first has code at block 2 rather
than at genesis. That runs **307 of the repo's 311 tests**. The four it cannot
run need Base archive history back to block 1117029 or Base's genesis WETH9
allocation at block 0.

Fuzz seed pinned (`FOUNDRY_FUZZ_SEED=0x5eed`) so a mutant cannot be killed by
a seed and survive under another.

### The lying harness, and what defused it

Any mutation of a file that feeds a deployed contract's creation code moves
that creation code, so `testSnapshotMatchesSource` fails — on every such
mutant, whatever it is. A filter that includes it reports KILLED for all of
them and measures nothing.

For those four files — both concretes and both interfaces — the suite command
therefore regenerates the rolling snapshots from the MUTATED source first
(`forge script ./script/Build.sol --sig "run()"`), and restores the generated
files afterwards. The source anchor then has nothing to say, and only a
behavioural test can kill anything.

**That it worked is measurable rather than asserted:** `A01` (the address
registry's root authority) and `I01` (the genesis head's preimage) SURVIVED
under that command. Neither could survive if the source anchor were what was
doing the killing.

### Proof the suite ran

`mutation-probe` aborts before the first mutant on a red, silent or zero-test
baseline, and scores KILLED only from the suite's own tally or a non-zero exit
with a tally present. Every probe log opens with `baseline: green (307
passed)` — `(311 passed)` for the two run against public RPC endpoints, `(312
passed)` for the re-probe after the new tests. 241 KILLED verdicts each come
from a run that reported a failing tally out of 307+ executed tests, and every
one of the 15 units produced at least one KILLED, so no unit is a filter that
matched nothing.

Where a run could not be trusted it is reported as such rather than scored:
two mutants time out because the binary search stops narrowing, and are
NO-RUN.

## Results

| unit | mutants | killed | not killed |
| --- | --- | --- | --- |
| `src/lib/LibRainDeploySnapshot.sol` | 70 | 70 | — |
| `src/lib/LibRainDeploy.sol` | 56 | 50 | 4 survived, 2 no-run |
| `src/concrete/MigrationRegistry.sol` | 34 | 34 | — |
| `src/abstract/RainDeploySuitesBase.sol` | 15 | 15 | — |
| `script/Build.sol` | 15 | 4 | 11 survived |
| `src/abstract/RainDeployVerifySnapshot.sol` | 14 | 13 | 1 survived |
| `src/concrete/AddressRegistry.sol` | 12 | 11 | 1 survived |
| `src/lib/LibMigrationRegistry.sol` | 12 | 12 | — |
| `src/abstract/RainDeployBroadcast.sol` | 7 | 7 | — |
| `src/abstract/RegistryDeploySuites.sol` | 7 | 4 | 3 survived |
| `src/abstract/RainDeployVerifyBase.sol` | 6 | 6 | — |
| `src/abstract/RainDeployVerifyChain.sol` | 6 | 6 | — |
| `src/interface/IMigrationRegistryV1.sol` | 5 | 4 | 1 survived |
| `src/lib/LibAddressRegistry.sol` | 3 | 3 | — |
| `src/interface/IAddressRegistryV1.sol` | 2 | 2 | — |
| **total** | **264** | **241** | **21 survived, 2 no-run** |

## The seven gaps this closes

Each row survived the first pass, has a test added here, and is re-probed
KILLED at `99b9ca9`.

| mutant | what walked past the suite | test added |
| --- | --- | --- |
| `W12` | the frozen record matched on the address a release RECORDS rather than the one it DERIVES | `testFrozenSnapshotMatchesTheDerivationNotTheRecordedAddress` |
| `W13` | `testSnapshotInternallyConsistent` checking only the first declared suite | `testSnapshotInternallyConsistentReachesEverySuite` |
| `V02` | the derivation clearing the derived address's code but not its nonce | `testDerivationClearsTheDerivedNonce` |
| `R06` | `run()` deriving the pins it is meant to check, making the pre-fork comparison a value against itself | `StalePinDeploy` leg of `testRunSelectsTheSuiteFromTheEnvBeforeTheKeyNeverDefaultsAndBroadcastsIt` |
| `R07` | `run()` dropping the suite's dependency list | `MissingDependencyDeploy` leg of the same test |
| `L32` | a read that REVERTS carrying exactly the bytes a successful answer would carry, accepted as an answer | `testCheckResolvedAddressesRevertingAddressAnswerReverts` |
| `L41` | `checkResolvedAddressesOnNetworks` stopping at the first network | `testCheckResolvedAddressesOnNetworksReachesEveryNetwork` |

The two broadcast legs go inside the existing test rather than beside it, and
answer to the `DEPLOYMENT_SUITE` it has already set: that variable is
process-wide and forge runs tests concurrently, so a second writer of it is a
second racer, which is what this contract's own docstring records having been.

## The twenty-three that are not gaps

**Equivalent — no behavioural difference (7)**

- `L13` `deployBlock = high` instead of `low`: `low` only rises to `mid + 1 <=
  high` and `high` only falls to `mid >= low`, so they meet exactly.
- `G03`, `G04` a candidate's `sourceCreationCode` taken from its recorded
  `CREATION_CODE` rather than `type(X).creationCode`: identical while the
  committed snapshot is current, which is the tree state every other check
  already enforces.
- `A01` the address registry's root authority: `CLAUDE.md` states that setting
  a real root is an ordinary source change that moves the creation code, the
  address, the code hash and the release together. Nothing should refuse it.
- `I01` `MIGRATION_HEAD_GENESIS`'s preimage: the interface constrains it to
  being nonzero, one shared value, and not a migration. All three still hold.
  The zero case (`I02`) is killed.
- `G01`, `W14` the released-suite concatenation and the record-walk root: this
  repo has frozen no release, so the record is empty, and every root and every
  concatenation of two empty lists is the same one. `W14` stays that way after
  the first release too — a walk of the wrong root returns empty and passes —
  which is the residue of #81 that survives its fix.

**Defensive guards nothing else can distinguish (3)**

- `L19` `mstore(0, 0)` before the factory call: the EVM masks addresses to 160
  bits everywhere the result is used, so a dirty scratch word changes no
  outcome.
- `L25` the `!success` clause: a failed call leaves `deployedAddress` zero
  because the assembly's own `if success` guard never writes it, so the
  zero-address clause catches the same case.
- `L55` `NoNetworks` in `deployAndBroadcast`: `deployToNetworks` raises the
  same error for the same input.

**Executed by no test (11)** — `D05`–`D15`, `script/Build.sol`'s `run()` and
`cutRelease()` and the regeneration they call. Nothing in the suite runs
either: doing so writes the repo's real generated files, which races the
emitter tests over those paths and would regenerate a stale snapshot out from
under `testSnapshotMatchesSource`. This is #132's subject and #138 is open for
it; note that #138 makes the BASE's entry points concrete and testable, while
`Build.build()`'s own wiring — `D11`–`D15` — stays unexecuted.

**Non-terminating (2)** — `L11` `low = mid` and `L12` `while (low <= high)`
both stop the binary search narrowing. The suite never reports, which is
NO-RUN rather than a verdict; a hang is not something a forge test can be
written to catch.

## Adversarial pass

One candidate, confirmed, already on the record: the four `LibRainDeploySnapshotTest`
emitter tests race in pairs over two committed `src/lib/` files and can zero
one. It was hit here as a baseline flake (2 failures in 12 runs of that
contract on `ed91bfa`) before #135 was found to be filed for it, with #137
open to fix it by giving the writers a directory.

**That race is deliberately not fixed here.** #137 fixes it properly, and this
branch touches none of the files #137 touches, so the two do not conflict.

The campaign itself was run with the race removed locally, which is the
conservative direction and not a convenient one: a flake can only ever ADD a
failure, so leaving it in would have scored some mutants KILLED on an
interleaving rather than on an assertion. Every KILLED verdict below therefore
comes from a test that actually discriminated, and the 70/70 on
`LibRainDeploySnapshot.sol` — the unit those four tests belong to — is a real
70, not a flaky one.

No other candidate survived refutation. The reads that looked promising —
`tagPrecedes` indexing `right[i]` off `left.length`, `freeze` creating the tag
directory before its writes, the already-deployed branch skipping the
dependency check — are each documented preconditions or documented decisions
with the guard that makes them safe in the same function.

## Ledger

`audit/mutation-test-scans.json` gains the second entry. Two keys beyond the
existing shape, because the run produced two outcomes the shape has nowhere to
put: `notExecutedBySuite` and `nonTerminating`. `filed` is empty and
`alreadyFiled` names #135, because the one confirmed candidate was already on
the record when the campaign reached it.

## QA

- **Discriminating tests:** `testFrozenSnapshotMatchesTheDerivationNotTheRecordedAddress`, `testSnapshotInternallyConsistentReachesEverySuite`, `testDerivationClearsTheDerivedNonce`, `testCheckResolvedAddressesRevertingAddressAnswerReverts`, `testCheckResolvedAddressesOnNetworksReachesEveryNetwork`, and the two new legs of `testRunSelectsTheSuiteFromTheEnvBeforeTheKeyNeverDefaultsAndBroadcastsIt` (`StalePinDeploy`, `MissingDependencyDeploy`). Each passes unmutated — 311 tests green on this branch, three consecutive runs — and each fails under exactly the mutation it is for: all seven mutants SURVIVED the pass at `ed91bfa` before these tests existed, and all seven are re-probed KILLED at `99b9ca9`.
- **Mutations applied:** 264 across 15 units, per-unit table above. The seven this PR closes, as `line -> mutation -> killing test`: `RainDeployVerifySnapshot.sol` `recorded == LibRainDeploy.zoltuAddress(released[j].creationCode)` -> `recorded == released[j].storedDeployedAddress` -> `testFrozenSnapshotMatchesTheDerivationNotTheRecordedAddress`; `RainDeployVerifySnapshot.sol` `i < suites.length` -> `i < suites.length && i < 1` -> `testSnapshotInternallyConsistentReachesEverySuite`; `RainDeployVerifyBase.sol` delete `vm.resetNonce(formulaAddress);` -> `testDerivationClearsTheDerivedNonce`; `RainDeployBroadcast.sol` `suite.storedDeployedAddress, suite.storedBytecodeHash` -> `LibRainDeploy.zoltuAddress(suite.creationCode), keccak256(suite.storedRuntimeCode)` -> the `StalePinDeploy` leg; `RainDeployBroadcast.sol` `suite.dependencies` -> `new address[](0)` -> the `MissingDependencyDeploy` leg; `LibRainDeploy.sol` `if (!success || returnData.length != 0x20)` -> `if (returnData.length != 0x20)` -> `testCheckResolvedAddressesRevertingAddressAnswerReverts`; `LibRainDeploy.sol` network loop `i < networks.length` -> `i < networks.length && i < 1` -> `testCheckResolvedAddressesOnNetworksReachesEveryNetwork`.
- **Oracle:** the interface and NatSpec contracts, not the implementation. `RainDeployVerifySnapshot`'s docstring states the record is matched "by address: the address a file DECLARES against the address a suite's creation code DERIVES". `deriveDeployment`'s states "the nonce goes too: `CREATE2` collides on a non-zero nonce as well as on non-empty code". `RainDeployBroadcast`'s states the recorded pins are passed rather than derived because "a guard that compares a value to itself is not a guard", and that `dependencies` is what "refuses to broadcast on any network where one of them has no code". `ResolvedAddressReadFailed`'s states a read that "reverts, answers nothing … or answers something that is not one word cannot be compared, and is never a pass". `checkResolvedAddressesOnNetworks`'s states it "runs `checkResolvedAddresses` on every network". Every expected value is read off those statements; none is copied from the code under test.
- **Category check:** #64 asks for the campaign re-run at the current commit, at whole-repo scope, and a second entry appended to `audit/mutation-test-scans.json` in the existing shape, prioritising the units with no ledgered coverage. Covered: whole repo at `ed91bfa`, 15 units and 264 mutants none of which were ledgered before, and the ledger entry. The issue's prioritisation list is stale in the one respect its own verification section flags: `script/Build.sol` now has `test/script/Build.t.sol`, and `RainDeployBroadcast.run` and `LibRainDeploySnapshot.freeze` both have tests.
