### PR TITLE
Add HyperEVM and Ethereum mainnet to the supported networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,7 @@
 ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
 BASE_RPC_URL=https://mainnet.base.org
 BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+ETHEREUM_RPC_URL=https://eth-pokt.nodies.app
 FLARE_RPC_URL=https://flare-api.flare.network/ext/C/rpc
+HYPEREVM_RPC_URL=https://rpc.hyperliquid.xyz/evm
 POLYGON_RPC_URL=https://polygon-bor-rpc.publicnode.com

--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -33,11 +33,13 @@ on:
       networks:
         type: string
         required: true
-        default: arbitrum base base-sepolia flare polygon
+        default: arbitrum base base-sepolia mainnet flare hyperliquid polygon
         description: |
           Which explorers to submit to. FOUNDRY's chain names, not the
-          `[rpc_endpoints]` aliases: `base-sepolia` is a chain name and
-          `base_sepolia` is rejected outright. The default is
+          `[rpc_endpoints]` aliases, and the two differ on three of the seven:
+          the aliases `base_sepolia`, `ethereum` and `hyperevm` are rejected
+          outright, and the chain names are `base-sepolia`, `mainnet` and
+          `hyperliquid`. The default is
           `LibRainDeploy.supportedNetworks()` spelled that way, i.e. every
           network the deploy broadcasts to, so it has to move when that does.
 jobs:

--- a/foundry.toml
+++ b/foundry.toml
@@ -77,7 +77,9 @@ recursive_deps = false
 arbitrum = "${ARBITRUM_RPC_URL}"
 base = "${BASE_RPC_URL}"
 base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
+ethereum = "${ETHEREUM_RPC_URL}"
 flare = "${FLARE_RPC_URL}"
+hyperevm = "${HYPEREVM_RPC_URL}"
 polygon = "${POLYGON_RPC_URL}"
 
 # `rainix-manual-sol-artifacts` passes `--verify` by default and exports exactly
@@ -88,9 +90,18 @@ polygon = "${POLYGON_RPC_URL}"
 # Both sections are checked against `LibRainDeploy.supportedNetworks()`, in both
 # directions, by `testSupportedNetworksAreFullyConfigured`. Adding a network is
 # an edit to all three or a red test, not a broadcast that discovers it.
+#
+# `chain` is stated on the entries whose alias foundry does not itself resolve
+# to a chain. An entry with neither `chain` nor `url` under such an alias is not
+# a missing key, it is a config error — "At least one of `url` or `chain` must
+# be present for Etherscan config with unknown alias" — raised while resolving
+# the section, so it takes down verification for every network in it and not
+# only its own.
 [etherscan]
 arbitrum = { key = "${CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY}" }
 base = { key = "${CI_DEPLOY_BASE_ETHERSCAN_API_KEY}" }
 base_sepolia = { key = "${CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY}" }
+ethereum = { key = "${CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY}", chain = 1 }
 flare = { key = "${CI_DEPLOY_FLARE_ETHERSCAN_API_KEY}" }
+hyperevm = { key = "${CI_DEPLOY_HYPEREVM_ETHERSCAN_API_KEY}", chain = 999 }
 polygon = { key = "${CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY}" }

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -24,8 +24,8 @@ import {RegistryDeploySuites} from "../src/abstract/RegistryDeploySuites.sol";
 ///
 /// Deploying is idempotent by construction. `deployToNetworks` checks the
 /// recorded address against the creation code before it forks anything, then
-/// skips any network that already has code there, so a partial run — three
-/// chains of five, one RPC down — is fixed by running it again rather than by
+/// skips any network that already has code there, so a partial run — five
+/// chains of seven, one RPC down — is fixed by running it again rather than by
 /// unpicking anything.
 ///
 /// `RegistryDeployChainTest` is what says whether this has been run and worked

--- a/src/abstract/RainDeployVerifyChain.sol
+++ b/src/abstract/RainDeployVerifyChain.sol
@@ -36,8 +36,8 @@ error CodeHashMismatchOnNetwork(
 ///
 /// This is the only group that can catch a suite that never deployed to a
 /// network, or that is not there any more. Neither is a fact the repo can hold:
-/// both can go false with nobody touching it — a release that reached four
-/// chains of five, a chain added to `supportedNetworks()` after a release that
+/// both can go false with nobody touching it — a release that reached six
+/// chains of seven, a chain added to `supportedNetworks()` after a release that
 /// therefore never got it, a deploy that silently failed.
 ///
 /// ## Released only, for the same reason source anchors the candidate only
@@ -108,7 +108,7 @@ abstract contract RainDeployVerifyChain is RainDeployVerifyBase {
     /// expectation.
     /// @param derived The derivation of every suite to check.
     function checkDeployedOnSupportedNetworks(DerivedDeploy[] memory derived) internal {
-        // Nothing to check is not a reason to touch five RPC endpoints. Forking
+        // Nothing to check is not a reason to touch seven RPC endpoints. Forking
         // to check nothing turns an outage into the failure of an assertion
         // that has no subject, which is the one failure this contract is
         // supposed to be legible against.

--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -85,8 +85,14 @@ library LibRainDeploy {
     /// Config name for Base Sepolia testnet.
     string constant BASE_SEPOLIA = "base_sepolia";
 
+    /// Config name for Ethereum mainnet.
+    string constant ETHEREUM = "ethereum";
+
     /// Config name for Flare network.
     string constant FLARE = "flare";
+
+    /// Config name for HyperEVM network.
+    string constant HYPEREVM = "hyperevm";
 
     /// Config name for Polygon network.
     string constant POLYGON = "polygon";
@@ -251,12 +257,14 @@ library LibRainDeploy {
     /// Returns the list of networks currently supported by Rain deployments.
     /// @return The list of supported network names.
     function supportedNetworks() internal pure returns (string[] memory) {
-        string[] memory networks = new string[](5);
+        string[] memory networks = new string[](7);
         networks[0] = ARBITRUM_ONE;
         networks[1] = BASE;
         networks[2] = BASE_SEPOLIA;
-        networks[3] = FLARE;
-        networks[4] = POLYGON;
+        networks[3] = ETHEREUM;
+        networks[4] = FLARE;
+        networks[5] = HYPEREVM;
+        networks[6] = POLYGON;
         return networks;
     }
 

--- a/test/concrete/MissingDependencyDeploy.sol
+++ b/test/concrete/MissingDependencyDeploy.sol
@@ -22,7 +22,7 @@ address constant ABSENT_DEPENDENCY = address(0xdeadbee5);
 /// dependency check by design and would say nothing about the list.
 ///
 /// One network, so the refusal names a chain that is the whole target set
-/// rather than the first of five. Keyed `second-address-candidate` for the
+/// rather than the first of seven. Keyed `second-address-candidate` for the
 /// reason `StalePinDeploy` gives.
 contract MissingDependencyDeploy is RainDeployBroadcast {
     /// @inheritdoc RainDeployBroadcast

--- a/test/src/abstract/RainDeployBroadcast.t.sol
+++ b/test/src/abstract/RainDeployBroadcast.t.sol
@@ -152,9 +152,9 @@ contract RainDeployBroadcastTest is Test {
         //
         // A fixture that names ONE network, so that where the broadcast went is
         // observable at all. `sDeploy` takes the default target set, and a suite
-        // deployed to all five chains and a suite deployed to the one chain the
+        // deployed to all seven chains and a suite deployed to the one chain the
         // repo asked for are indistinguishable from a fixture that asks for all
-        // five.
+        // seven.
         ExampleDeploySingleNetwork single = new ExampleDeploySingleNetwork();
 
         // Derived here from the same source the declaration derives them from,
@@ -198,7 +198,7 @@ contract RainDeployBroadcastTest is Test {
         // arbitrum for this fixture's single-element override, polygon for the
         // default. That is the whole of the difference an assertion can see, and
         // an override `run()` ignored is a repo that asked for one chain getting
-        // a suite on five — with a revert partway through leaving a dispatch
+        // a suite on seven — with a revert partway through leaving a dispatch
         // half done.
         //
         // `testDeployNetworksDefaultsToSupportedNetworks` asserts the default
@@ -258,7 +258,7 @@ contract RainDeployBroadcastTest is Test {
     /// before the `CREATE2` goes out compares the recorded address against the
     /// recorded creation code, both of which come out of the same generated
     /// file. That catches a stale PIN and cannot catch a snapshot of the wrong
-    /// CONTRACT, so without this the bytes reaching five chains are whatever the
+    /// CONTRACT, so without this the bytes reaching seven chains are whatever the
     /// generated file happens to hold. `CREATE2` at a zero salt makes that
     /// permanent: the wrong bytes take the wrong bytes' own address, on every
     /// chain the dispatch reached, and the dispatch is `workflow_dispatch` on a

--- a/test/src/abstract/RainDeployVerifyChain.t.sol
+++ b/test/src/abstract/RainDeployVerifyChain.t.sol
@@ -43,10 +43,10 @@ import {
 /// "nothing is deployed at this address" from something the fixture arranged
 /// into a claim about the world. That claim is false here: the exemplar's
 /// addresses come from `src/generated/candidate/`, which is exactly what
-/// `Manual sol artifacts` broadcasts, and `AddressRegistry` is live on all five
-/// supported networks. A negative case resting on it asserts nothing and
-/// reports `next call did not revert as expected` — a fixture that only worked
-/// while the repo had not yet done the thing it exists to do.
+/// `Manual sol artifacts` broadcasts, and `AddressRegistry` is live on five of
+/// the seven supported networks. A negative case resting on it asserts nothing
+/// and reports `next call did not revert as expected` — a fixture that only
+/// worked while the repo had not yet done the thing it exists to do.
 ///
 /// Pointing the fixture at a mock nobody deploys would move that dependency
 /// rather than remove it: the Zoltu factory is permissionless, so no address is
@@ -94,7 +94,7 @@ contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain
 
     /// A version that is not on a network MUST fail, naming the network, the
     /// version and the address. This is the whole reason the group exists: a
-    /// release that reached four chains of five, or a chain added after a
+    /// release that reached six chains of seven, or a chain added after a
     /// release that therefore never got it, is invisible to every other check.
     function testChainNotDeployedReverts() external {
         // Emptied, and left persistent, so every fork carries an empty account
@@ -164,7 +164,7 @@ contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain
     ///
     /// This contract is where it belongs because it already forks every
     /// supported network. Asserting it from the empty-set side would hand the
-    /// contract that exists to need no RPC endpoint the five-endpoint dependency
+    /// contract that exists to need no RPC endpoint the seven-endpoint dependency
     /// the early return removes from it.
     function testChainWithASingleSubjectDoesFork() external {
         (bool activeBefore,) = address(vm).call(abi.encodeWithSignature("activeFork()"));

--- a/test/src/abstract/RegistryDeployChain.t.sol
+++ b/test/src/abstract/RegistryDeployChain.t.sol
@@ -28,20 +28,20 @@ import {RegistryDeploySuites} from "../../../src/abstract/RegistryDeploySuites.s
 /// itself.
 contract RegistryDeployChainTest is RegistryDeploySuites, RainDeployVerifyChain {
     /// Nothing to check MUST NOT touch an RPC endpoint. This repo has released
-    /// nothing, so this is the branch every CI run takes: forking five networks
+    /// nothing, so this is the branch every CI run takes: forking seven networks
     /// to check nothing turns an outage into the failure of an assertion with
     /// no subject, which is the one failure this contract exists to stay
     /// legible against.
     ///
     /// The ABSENCE of a fork is what is asserted, because the pass is identical
-    /// either way — the matrix that forks all five and finds nothing to check on
+    /// either way — the matrix that forks all seven and finds nothing to check on
     /// each of them passes too, and is the only thing this contract would have
     /// done differently. `vm.activeFork()` reverts when nothing is selected, so
     /// the low-level call failing IS "no network was reached".
     ///
     /// It runs the whole inherited entry point rather than handing the matrix an
     /// empty array, so the derivation is inside what is asserted: a fork opened
-    /// while deriving would touch the same five endpoints for the same nothing.
+    /// while deriving would touch the same seven endpoints for the same nothing.
     ///
     /// The empty released set is asserted rather than assumed, because it is the
     /// premise and not the property. The first release gives this contract a

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -194,16 +194,18 @@ contract LibRainDeployTest is Test {
         );
     }
 
-    /// `supportedNetworks` MUST return exactly 5 networks in the expected
+    /// `supportedNetworks` MUST return exactly 7 networks in the expected
     /// order matching the library constants.
     function testSupportedNetworks() external pure {
         string[] memory networks = LibRainDeploy.supportedNetworks();
-        assertEq(networks.length, 5);
+        assertEq(networks.length, 7);
         assertEq(networks[0], LibRainDeploy.ARBITRUM_ONE);
         assertEq(networks[1], LibRainDeploy.BASE);
         assertEq(networks[2], LibRainDeploy.BASE_SEPOLIA);
-        assertEq(networks[3], LibRainDeploy.FLARE);
-        assertEq(networks[4], LibRainDeploy.POLYGON);
+        assertEq(networks[3], LibRainDeploy.ETHEREUM);
+        assertEq(networks[4], LibRainDeploy.FLARE);
+        assertEq(networks[5], LibRainDeploy.HYPEREVM);
+        assertEq(networks[6], LibRainDeploy.POLYGON);
     }
 
     /// PROPERTY: `[rpc_endpoints]` and `[etherscan]` in `foundry.toml` are
@@ -1223,7 +1225,7 @@ contract LibRainDeployTest is Test {
     ///
     /// Two networks rather than `supportedNetworks()`. What is under test is
     /// that the loop visits every network it is given, which two prove as well
-    /// as five; the roster itself is `testSupportedNetworks`'s job. These are
+    /// as seven; the roster itself is `testSupportedNetworks`'s job. These are
     /// the two networks the rest of this suite forks, so the test does not
     /// depend on the reliability of RPC endpoints nothing else here touches.
     function testCheckResolvedAddressesOnNetworksEachNetwork() external {
@@ -1273,7 +1275,7 @@ contract LibRainDeployTest is Test {
     /// just as happily — and the mismatch case above is one network, so it
     /// cannot tell them apart either. What separates them is a target that
     /// answers differently on a LATER network, which is exactly the deployment
-    /// this matrix exists for: one chain of five holding a value nobody looked
+    /// this matrix exists for: one chain of seven holding a value nobody looked
     /// at.
     ///
     /// The first network is the one the target agrees on, so nothing fails


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.solmem/issues/150

Removes `audit/audits.json` and the `README.md` link that pointed at it.
`audit/mutation-test-scans.json` and `audit/protofire/` are untouched.

## Everything that referenced the file

Checked rather than assumed, because two of these were the ones most likely to
break on a deletion:

| Where | Reference | Action |
| --- | --- | --- |
| `README.md:77` | a markdown link to `audit/audits.json` in the `## Audit` section | removed, see below |
| `REUSE.toml` | covers `audit/**/` as a directory glob, no per-file entry | none — the directory still holds `mutation-test-scans.json` and `protofire/`, and `nix develop -c reuse lint` is compliant at 68/68 files after the deletion |
| `.soldeerignore` | excludes `/audit` wholesale | none |
| CI | `.github/workflows/rainix.yaml` and `package-release.yaml` are `uses:` lines into the rainix reusables; at `rainlanguage/rainix` HEAD no reusable workflow mentions `audit` (the only `audit` string in that repo's workflows is `npm --no-audit`) | none — there is no glob or gate to update |
| `.audit/scope.json` | the audit skill's own scope snapshot, taken at `30ecd99` on 2026-07-25, predates the file and never listed it | none |
| org-wide code search | `audits.json` returns one hit in `rainlanguage` — the `README.md` line above — and zero across `gildlab`, `cyclofinance`, `S01-Issuer`, `ST0x-Technology`, `ST0x-intelligence`, `h20liquidity`, `raincommercial`, `rain-archive` | none |

After the change `git grep -In audits` over every tracked non-PDF file returns
nothing.

The one live thing that is about this file is not a code reference:
https://github.com/rainlanguage/rainix/issues/321, still open, proposes a
`rainix-sol` drift-report job whose entire input is a consumer-side
`audit/audits.json`. Nothing there executes yet, so nothing breaks, but its
premise is gone — flagged, not edited, from here.

## The README section

The section stays; only the pointer to the deleted file goes. The sentence that
carried the link stated the audited scope, so it is reworded to state the same
scope without the link rather than dropped:

> Scope was all of `src/` at those commits, the twelve contracts the report's
> own scope table lists.

That claim is verified in this clone, not carried over from #137: at both
`228b35c6725877e7fbcd2432b4c692357f16f510` and
`26bce6197383f193e35326bab4d4424cf6eafde7`, `git ls-tree -r --name-only <c> --
src/` is exactly twelve files, and both commits are ancestors of `HEAD`.

## What #88 needs now

Nothing in this repo, and it should stay closed.

https://github.com/rainlanguage/rain.solmem/issues/88 is a MEDIUM audit finding
whose hazard is "nothing in the repo records which commit was audited or that
main has moved past it". After this PR the record is still there, in the
`## Audit` section of `README.md`: it names both reviewed commits, links the
report PDF — which nothing else in the repo did before #137 — states the
audited scope, says outright that today's `src/` is not that tree, and gives the
command that measures the drift. What this PR deletes is a second, machine-only
copy of that record with no machine reading it.

The part of #88 that is genuinely unlanded is its third ask, the non-blocking CI
drift report. That was never in this repo's gift — its CI is two `uses:` lines
into rainix reusables — and it lives as
https://github.com/rainlanguage/rainix/issues/321. That issue is the one that
needs a decision, and it needs it independently of #88: as written it reads a
manifest that now exists nowhere, so it is either re-scoped to derive the
audited commit from something that does exist, or the manifest is reintroduced
deliberately as an org-wide convention with the reader landing in the same
change, or drift reporting is dropped. Reintroducing it here first would
recreate exactly the file #150 removes.

Not reopened or edited by this PR, per the work order.

## QA

- Discriminating tests: n/a as forge tests — the diff is one deleted JSON file
  and two reflowed README lines, no Solidity, and a test asserting a path's
  absence would be the same unread ceremony this PR removes. The three
  discriminating checks, each failing on a mutant and passing here: **A**
  `git grep -In "audits" -- . ':!*.pdf'` — 1 hit on `main` (`README.md:77`), **0
  on this branch**; **B** `git ls-files audit/` — must still list
  `mutation-test-scans.json` and the Protofire PDF, **2 entries on this
  branch**; **C** `nix develop -c reuse lint` — **compliant, 68 / 68 files**
  (69 / 69 on `main`, the difference being the deleted file itself).
- Mutations applied: **M1** restore `main`'s `README.md` and
  `audit/audits.json` -> check A goes 0 hits -> 1 hit, `README.md:77` -> killed.
  **M2** also `git rm audit/mutation-test-scans.json` -> check B goes 2 entries
  -> 1 entry -> killed; this is the overreach #150 explicitly forbids, and it is
  the mutant worth having. **M3** delete the `"audit/**/"` glob from
  `REUSE.toml`, on the theory that a per-file entry was what covered the deleted
  file -> check C reports **not compliant, 66 / 68**, the two surviving audit
  files losing their licence -> killed, which is why `REUSE.toml` is unchanged
  here. The three checks move independently across the mutants — 0/1 hits,
  2/1 entries, 68/66 files — so they ran rather than matching nothing.
- Oracle: https://github.com/rainlanguage/rain.solmem/issues/150 for what must
  go and what must stay; the Protofire report and `git` for the scope sentence
  that replaces the link — the twelve files were re-derived here with
  `git ls-tree -r --name-only <commit> -- src/` at both review commits, not
  taken from #137's body.
- Category check: the issue asks A remove `audit/audits.json`, B remove the
  `README.md` line pointing at it, C leave `audit/mutation-test-scans.json` and
  `audit/protofire/` alone. Covered A, B, C. Its fourth paragraph — "reopen or
  replace #88 if the drift it names is still worth tracking" — is answered in
  words above and deliberately not acted on, per the work order.

## QA
- Discriminating tests: `LibRainDeployTest.testSupportedNetworks` (the roster
  and its order), `LibRainDeployTest.testSupportedNetworksAreFullyConfigured`
  (`supportedNetworks()` against both `foundry.toml` sections, both
  directions), `LibRainDeployTest.testZoltuFactoryCodehash` (forks every
  supported network and reads the factory on it) — the first two each fail
  under a mutation that reverts one half of this diff, shown below; the third
  passes on seven forks, which is the only thing that says the two new
  `[rpc_endpoints]` aliases resolve and the Zoltu factory is live with its
  expected codehash on Ethereum and HyperEVM. Verified by running
  `nix develop -c forge test --match-contract LibRainDeployTest --match-test
  'testSupportedNetworks|testZoltuFactoryCodehash'` → 3 passed, 0 failed.
- Mutations applied:
  - `foundry.toml` `[etherscan] hyperevm` line deleted → killed by
    `testSupportedNetworksAreFullyConfigured`.
  - `foundry.toml` `[rpc_endpoints] ethereum` line deleted → killed by
    `testSupportedNetworksAreFullyConfigured`.
  - `foundry.toml` extra `[etherscan] optimism` key no network names → killed
    by `testSupportedNetworksAreFullyConfigured` (the reverse direction).
  - `networks[5] = HYPEREVM` → `POLYGON`, keeping the length at seven → killed
    by `testSupportedNetworksAreFullyConfigured`.
  - `networks[3]`/`networks[4]` swapped, `ETHEREUM` after `FLARE` → killed by
    `testSupportedNetworks` (`assertion failed: flare != ethereum`), and
    SURVIVED `testSupportedNetworksAreFullyConfigured`, which asserts membership
    rather than order — the two tests are not redundant.
  - `ETHEREUM = "ethereum"` → `"mainnet"` → killed by
    `testSupportedNetworksAreFullyConfigured`
    (`supported network has no [rpc_endpoints] alias: mainnet`).
  - `HYPEREVM = "hyperevm"` → `"hyperliquid"` → killed by
    `testSupportedNetworksAreFullyConfigured`
    (`supported network has no [rpc_endpoints] alias: hyperliquid`).
- Oracle: every value here comes from outside this repo's source. Chain ids and
  env var names are rainix's `NETWORKS` table in
  `rainix-static/src/rpc_preflight.rs` — `ethereum` is chain 1 reading
  `ETHEREUM_RPC_URL`, `hyperevm` is chain 999 reading `HYPEREVM_RPC_URL`. The
  `--chain` spellings are foundry's own parser, which rejects `ethereum`,
  `hyperevm` and `base_sepolia` and names `mainnet`, `hyperliquid` and
  `base-sepolia` in the rejection. The HyperEVM verifier is Etherscan's V2
  `chainlist` endpoint. Which chains already hold the Zoltu factory and
  `AddressRegistry` is `cast code` against the live chains, not anything the
  repo records.
- Category check: the ask is (a) both chains in `supportedNetworks()`, (b)
  `[rpc_endpoints]` and `[etherscan]` in lockstep, (c) every other place the
  set is enumerated, (d) the secret names, by name, (e) whether HyperEVM has an
  Etherscan-family verifier. Covered a, b, c, d, e. One enumeration site carries
  no test: the `networks` default in `manual-sol-verify.yaml`. Nothing reads it
  — it is a `workflow_dispatch` default — and asserting it would need a second
  hand-written alias-to-chain-name mapping in the test, since three of the seven
  differ, which is one more enumeration of the set rather than one fewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ethereum and HyperEVM networks.
  * Added RPC endpoint configuration for both networks.
  * Expanded deployment and verification coverage to seven supported networks.
* **Documentation**
  * Updated deployment and verification guidance to reflect the expanded network coverage.
* **Tests**
  * Updated network coverage checks to include Ethereum and HyperEVM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->