### PR TITLE
Strip release-process narration from per-repo docs

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,27 +1,5 @@
 name: Package Release
-# Deploy repo: a manual `sol-v*` tag is the sole release trigger. This repo
-# carries deployed concretes (`AddressRegistry`, `MigrationRegistry`) whose
-# address + codehash consumers pin, which is exactly the shape
-# rainix-tag-release exists for and exactly the shape rainix-autopublish's
-# merge-driven, next-version lifecycle is wrong for: autopublish bumps the
-# release version on every merge while the frozen deploy tag only advances at
-# deploy time.
-#
-# The tag names the version; rainix-tag-release runs `cutRelease()`, which
-# freezes src/generated/<tag>/ AND regenerates the released-suites lib that
-# declares it in one call, then verifies the live chains match the fresh pins,
-# publishes rain-deploy to Soldeer, and commits both back to main. One call,
-# because a frozen record no declaration names is a release every check silently
-# stops asking about.
-#
-# The on-chain deploy is separate and manual, run BEFORE tagging; this never
-# broadcasts. The chain verification inside rainix-tag-release is what fails if a
-# newly declared release is not on chain, and that is the intended gate: a
-# release is declared here only once it is a deployment that already happened.
-#
-# Switching lifecycles retracts nothing: every version already published stays
-# published, and consumers pin exact versions, so this changes who cuts a
-# release and nothing about how anyone consumes one.
+# Deploy repo: released by a manual `sol-v*` tag via rainix-tag-release.
 on:
   push:
     tags:

--- a/README.md
+++ b/README.md
@@ -393,11 +393,9 @@ Three separate steps, in this order. Nothing automatic ever broadcasts.
    This repo has released none, so today it has nothing to check and passes; it
    gets a subject the moment step 3 freezes one, and is red from then until step
    1 has been run everywhere. That is the order these steps are in.
-3. **Tag.** Push a `sol-v*` tag. `rainix-tag-release` regenerates the snapshot
-   for the version the tag names, verifies the live chains against those fresh
-   pins, publishes to Soldeer and commits the frozen snapshot back to `main`. It
-   verifies and publishes; it never broadcasts, which is exactly why step 1
-   cannot be folded into it.
+3. **Tag.** Push a `sol-v*` tag, the sole release trigger. It verifies and
+   publishes but never broadcasts, which is exactly why step 1 cannot be folded
+   into it. The release mechanics are `rainix-tag-release`'s.
 
 This is a deploy repo: it carries deployed concretes whose addresses and
 codehashes consumers pin, so releases are **manual `sol-v*` tags**, not merges.


### PR DESCRIPTION
Docs-only. Strip release-process narration that this per-repo doc restates but does not own.

Human ruling (2026-08-20): "you really shouldn't put release processes in the per repo docs because it's super fragile." The release process is owned by rainix's `rainix-tag-release.yaml` reusable; per-repo restatements drift the moment the reusable changes — which just happened: rainlanguage/rainix#338 / rainlanguage/rainix#339 made tag-release push-free, so this repo's "commits the frozen snapshot back to main" was already factually wrong.

- Ruling / audit rule: https://github.com/rainlanguage/claude-audit-skills/issues/91
- Philosophy (per-repo docs hold only what an agent would get WRONG from the repo itself; anything owned elsewhere stays absent): https://github.com/rainlanguage/rainix/issues/298

## Removed
- `.github/workflows/package-release.yaml` — collapsed the ~23-line header comment (rainix-tag-release runs cutRelease / freezes + regenerates the released-suites lib / verifies chains / publishes to Soldeer / commits both back to main, plus the why-not-autopublish lifecycle rationale) to one line of deploy-repo identity.
- `README.md` "Deploying, and then releasing" step 3 — removed the `rainix-tag-release` mechanics (regenerate snapshot / verify chains / publish to Soldeer / commit frozen snapshot back to main — now stale).

## Kept (repo-local facts / product docs)
The three-step deploy→verify→tag ordering and why it holds (deploy is idempotent, key-custody, workflow_dispatch-only; verify is scoped to released suites; a tag verifies and publishes but never broadcasts, which is why the deploy cannot fold into it); the lifecycle paragraph (`[external.package].version` is the last publish, historical versions unaffected). `CLAUDE.md` is unchanged — its release bullet already carries only repo-local invariants, no shared-workflow mechanics. `cutRelease()` docs elsewhere are left intact: it is THIS repo's own product code, not shared-workflow narration.

## QA
- Discriminating tests: n/a — docs-only.
- Mutations applied: n/a — docs-only.
- Oracle: https://github.com/rainlanguage/rainix/issues/298 + the ruling.
- Category check: strip release-process narration, covered (package-release.yaml comment + README release section).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified release workflow documentation.
  * Clarified that releases are manually triggered by pushing `sol-v*` tags.
  * Updated tagging guidance to explain that verification and publishing occur without broadcasting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->