### PR TITLE
ci: drop snapshot-generate-cmd from package-release

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -9,5 +9,4 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-tag-release.yaml@main
     with:
       soldeer-package: rain-deploy
-      snapshot-generate-cmd: forge script ./script/Build.sol --sig "cutRelease()" && forge fmt
     secrets: inherit


### PR DESCRIPTION
rainlanguage/rainix#343 removes the `snapshot-generate-cmd` input from the
`rainix-tag-release` reusable workflow. This repo's `package-release.yaml`
references that workflow at `@main` and passes the input explicitly, so the
moment #343 merges every `sol-v*` tag here fails with `Invalid input,
snapshot-generate-cmd is not defined in the referenced workflow` and publishes
nothing. Removing the line ahead of that merge makes the two safe in either
order.

## This is a no-op today

The value this repo passes is byte-identical to the input's current default on
rainix `main`:

| | value |
| --- | --- |
| passed here | `forge script ./script/Build.sol --sig "cutRelease()" && forge fmt` |
| rainix `main` default | `forge script ./script/Build.sol --sig "cutRelease()" && forge fmt` |

So the release runs the same command with the line and without it — this PR
changes no release behaviour on its own. After #343 the workflow runs the
non-freezing `run()` entry point instead; that behaviour change belongs to
#343 and lands whether or not this line is still here.

`soldeer-package` is the only `with:` key left, and #343 does not touch it.

## QA

- Discriminating tests: n/a - the diff deletes one YAML line from a caller
  workflow. The behaviour it used to select (which command the release runs)
  lives in `rainix-tag-release`, not in this repo, and is unit-tested there by
  #343. The only claim this PR makes that is checkable here is the
  value/default equivalence, verified under Oracle below.
- Mutations applied: n/a - ran
  `nix run github:rainlanguage/adversarial-mutation-test#mutation-probe -- mutants.toml`,
  which reports `error: cannot read mutants.toml`. This repo has no
  `mutants.toml` and the diff touches no Solidity or Rust source, so there is
  nothing to mutate.
- Oracle: `.on.workflow_call.inputs["snapshot-generate-cmd"].default` in
  `.github/workflows/rainix-tag-release.yaml` at `rainlanguage/rainix@main` -
  read from upstream rather than restated from the issue. Both that default and
  this repo's passed value were parsed with `yq` (not eyeballed, so YAML
  quoting cannot fool the comparison) and are the identical string. That
  equivalence is what makes the deletion a no-op. Independently,
  `actionlint` on the edited file is clean, and the only `with:` key left,
  `soldeer-package`, is a declared and required input both today and after
  #343.
- Category check: #344 asks this repo to drop the line; covered. The remaining
  four callers and the `RAINIX_SHA` bump are separate items on the same issue,
  so this is Refs, not Closes.

### Not run

- The repo's own `rainix-sol` suite was not run locally - `forge` is not
  available in the authoring environment. It runs on this PR in CI, and no
  Solidity changed.
- The release path itself cannot be exercised outside a real `sol-v*` tag push,
  so the end-to-end proof for this line is #343's own end-to-end evidence plus
  the string equivalence above.

Part of rainlanguage/rainix#344, which tracks all five callers plus the
`RAINIX_SHA` bump - this PR is one of them and does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the package release process by removing unnecessary automated steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->