### PR TITLE
Delete the "load-bearing" filler

### DIFF
--- a/src/lib/LibRainDeploySnapshot.sol
+++ b/src/lib/LibRainDeploySnapshot.sol
@@ -1282,7 +1282,7 @@ library LibRainDeploySnapshot {
     ///
     /// Strictly greater, so the newest tag itself is refused too: equality is
     /// not "follows". `SnapshotAlreadyFrozen` also refuses that one, and both
-    /// must hold — neither guard is load bearing alone.
+    /// must hold — dropping either one leaves cases the other does not refuse.
     ///
     /// The record root and the tag are parameters, so the refusal is reachable
     /// without a record on disk to re-cut or a `foundry.toml` to rewrite, for
@@ -1307,9 +1307,9 @@ library LibRainDeploySnapshot {
     /// in that order, in one call.
     ///
     /// Every guard runs, and every byte that will be written is in hand, BEFORE
-    /// `<tag>/` is created. That ordering is load bearing rather than tidy.
-    /// Filesystem cheatcodes are not undone by a revert, so a throw once the
-    /// directory exists leaves a partial record behind — and a partial record is
+    /// `<tag>/` is created. Filesystem cheatcodes are not undone by a revert,
+    /// so a throw once the directory exists leaves a partial record behind —
+    /// and a partial record is
     /// a frozen tag, which `SnapshotAlreadyFrozen` then refuses the retry of.
     /// The only exit from that state is deleting a directory this design calls
     /// append-only, so the release is wedged by the failure rather than merely

--- a/test/src/lib/GeneratedSnapshotShape.t.sol
+++ b/test/src/lib/GeneratedSnapshotShape.t.sol
@@ -177,8 +177,8 @@ contract GeneratedSnapshotShapeTest is RegistryDeploySuites, Test {
     /// selects is the contract the candidate is anchored to.
     ///
     /// `artifactPath` is the one field of a suite that nothing derives, and
-    /// until this assertion nothing checked either. It is load bearing twice
-    /// over: `LibRainDeploy` prints it as the `forge verify-contract` command a
+    /// until this assertion nothing checked either. Two things read it:
+    /// `LibRainDeploy` prints it as the `forge verify-contract` command a
     /// human runs against a freshly broadcast contract, and
     /// `candidateContractName` above takes the contract this whole shape spec
     /// is about out of it. Only the `:<Name>` half was ever read by a check —

--- a/test/src/lib/LibRainDeploySnapshot.t.sol
+++ b/test/src/lib/LibRainDeploySnapshot.t.sol
@@ -1957,9 +1957,8 @@ contract LibRainDeploySnapshotTest is Test {
 
     /// The newest tag ITSELF MUST be refused: equality is not "follows". The
     /// fail-safe boundary, and the one case `SnapshotAlreadyFrozen` also
-    /// refuses — both must hold, so neither is load bearing alone and this one
-    /// holds against a record root whose directories are not where a freeze
-    /// would look for them.
+    /// refuses — both must hold, and this one holds against a record root
+    /// whose directories are not where a freeze would look for them.
     function testCheckReleaseFollowsRecordRefusesTheNewestTagItself() external {
         writeFixture(string.concat(EQUAL_FIXTURE_ROOT, "/0_2_0/", FIXTURE_CONTRACT, ".sol"));
 


### PR DESCRIPTION
Removes the banned `load-bearing` filler from this repo's committed source.

The phrase rates a finding instead of stating one, and the reader can do the rating.
Where the surrounding sentence already named the consequence, the phrase is simply
deleted; otherwise it is replaced by the consequence it was standing in for. No
substitute rating word ("crucial", "key", "critical", "the crux", "significant",
"notably") was introduced anywhere in the diff.

Closes nothing — no issue exists for this. Part of an org-wide sweep; one PR per
affected repo. GitHub code search finds only some of the forms, so the sweep was run
against fresh clones of all 151 org repos, matching `load[-_ ]?bearing` case-insensitively
plus a check for the phrase wrapped across two comment lines.

### Occurrences removed

| File | Count |
| --- | --- |
| `src/lib/LibRainDeploySnapshot.sol` | 2 |
| `test/src/lib/GeneratedSnapshotShape.t.sol` | 1 |
| `test/src/lib/LibRainDeploySnapshot.t.sol` | 1 |

## QA

- Discriminating tests: n/a — nothing in the diff changes behaviour, so there is no
  behaviour for a test to discriminate.
- Mutations applied: n/a — the diff is comments and prose only. `mutation-probe` mutates
  source lines and asks whether the suite kills them; this diff changes no source line,
  so every mutant it could generate is a mutant of code this PR did not touch.
- Oracle: the code each comment describes. Every rewrite states the consequence the
  phrase was gesturing at, read off the surrounding implementation rather than invented.
- Category check: the request is "remove every occurrence from committed source";
  this repo's occurrences are all removed and a re-grep over the branch finds none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified safeguards preventing non-monotonic releases and duplicate snapshots.
  * Documented freeze ordering and the potential for partial records after filesystem writes.
  * Improved explanations of artifact-path usage and equal-tag rejection behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->