### PR TITLE
Read the deployment key instead of writing it into the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,14 @@ it. The deployer already holds HYPE, because that is what it pays gas in, so it
 credits itself:
 
 ```sh
-HYPERCORE_CREDIT_WEI=10000000000000000 DEPLOYMENT_KEY=0x... \
+read -rs DEPLOYMENT_KEY && export DEPLOYMENT_KEY
+HYPERCORE_CREDIT_WEI=10000000000000000 \
   nix develop -c forge script script/CreditHyperCore.sol:CreditHyperCore --legacy
 ```
+
+The key is read rather than written into the command, because a
+`DEPLOYMENT_KEY=0x...` prefix is a private key in the shell's history file,
+where it outlives the run and the terminal both.
 
 Run exactly that first, without `--broadcast`: it is a dry run against a fork of
 HyperEVM that executes every guard and the transfer itself and sends nothing, so

--- a/script/CreditHyperCore.sol
+++ b/script/CreditHyperCore.sol
@@ -34,9 +34,14 @@ import {LibHyperCore} from "../src/lib/LibHyperCore.sol";
 /// It is run by hand instead:
 ///
 /// ```sh
-/// HYPERCORE_CREDIT_WEI=10000000000000000 DEPLOYMENT_KEY=0x... \
+/// read -rs DEPLOYMENT_KEY && export DEPLOYMENT_KEY
+/// HYPERCORE_CREDIT_WEI=10000000000000000 \
 ///   forge script script/CreditHyperCore.sol:CreditHyperCore --legacy
 /// ```
+///
+/// The key is read rather than written into the command: a
+/// `DEPLOYMENT_KEY=0x...` prefix leaves a private key in the shell's history
+/// file, where it outlives both the run and the terminal.
 ///
 /// Without `--broadcast` that is a dry run against a fork of HyperEVM, which
 /// executes every guard and the transfer itself and sends nothing. Do that


### PR DESCRIPTION
Follow-up to #147, which merged while this was being written, so the fix missed
the merge by about a minute rather than being left out on purpose.

CodeRabbit's merge-risk note on #147 was right: the invocation that PR
documented prefixed `DEPLOYMENT_KEY=0x...` to the command, which writes a
private key with real money behind it into the shell's history file, where it
outlives both the run and the terminal. `main` currently carries that
instruction in the README and in the `CreditHyperCore` NatSpec.

It is the only place in the repo that documents a key on a command line at all
— the deploy reaches its key through a workflow secret and never spells one out
— so it is also the only place that could teach the habit.

`read -rs` takes the key off the terminal without echoing it and without a
history entry carrying its value:

    read -rs DEPLOYMENT_KEY && export DEPLOYMENT_KEY
    HYPERCORE_CREDIT_WEI=10000000000000000 \
      nix develop -c forge script script/CreditHyperCore.sol:CreditHyperCore --legacy

Same variable, same script, same env read in `run()`. Nothing about the
mechanism changes and no Solidity outside a comment is touched.

## QA

- Discriminating tests: n/a — the diff is one README passage and the NatSpec
  block that mirrors it. There is no behaviour here to discriminate on: the
  compiled artifact is byte-identical, because the only `.sol` change is inside
  a `///` comment. A test asserting the text of a comment would pin the mirror
  rather than the source, which is the failure mode section 4 of the QA guide
  names.
- Mutations applied: n/a for the same reason — there is no line to break. The
  library this documents was mutation-tested in #147 (13 mutants, 12 killed, M10
  disclosed as surviving and unreachable), and this diff does not touch it.
- Oracle: the shell's own behaviour, not the implementation. A `VAR=value cmd`
  prefix is part of the command line and lands in `HISTFILE` under default bash
  and zsh settings; `read -rs` assigns without echoing and without putting the
  value in the history entry. Verified against `main` that the pattern being
  replaced is the only one of its kind in the repo:
  `grep -rn 'DEPLOYMENT_KEY=' ` finds it in `README.md` and
  `script/CreditHyperCore.sol` and nowhere else.
- Category check: covers the whole of CodeRabbit's finding on #147 — both
  places the command is written out, not just the README it was raised against.
  Deliberately not covered: how the key gets onto the machine in the first
  place, and any change to `run()` or its env reads, both of which are
  mechanism rather than documentation and neither of which the finding is
  about.

`forge fmt --check` clean and `LibHyperCoreTest` 13/13 locally on this tree.
