### PR TITLE
Check generated files are current at PR time

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -1,0 +1,6 @@
+name: Git is clean
+on: [push]
+jobs:
+  git-clean:
+    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
+    secrets: inherit


### PR DESCRIPTION
`src/generated/` is committed here, but nothing re-derived it on a push. The
first thing that regenerated it was `rainix-tag-release` at tag time — after
`Manual sol artifacts` had already broadcast the deploy. `rainix-tag-release`
assumes a PR-time twin of that regen exists; in this repo it did not.

Adds `.github/workflows/git-clean.yaml` calling
`rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main`, which
re-runs `script/Build.sol`, `forge build`, `forge fmt`, then
`git diff --exit-code`.

Names follow the 2026-08-27 ruling on #152: file `git-clean.yaml`, workflow
`name: Git is clean`, job id `git-clean`. Shape copied from rain.metadata.deploy
and rain.factory.deploy, which are identical to each other and differ from this
only in the pre-ruling job id.

Closes #152

## QA
- Discriminating tests: the workflow's own run is the test — n/a as a Solidity
  test, a CI-only diff has no unit test that could exercise it. Run
  https://github.com/rainlanguage/rain.deploy/actions/runs/33043677967 on this
  branch is green, and every step that does the checking actually executed
  rather than being skipped: `Regenerate generated sources` ran
  `forge script ./script/Build.sol` ("Compiling 56 files with Solc 0.8.25",
  "Script ran successfully. Gas used: 3051805"), `Build Solidity` ran
  `forge build` ("Compiling 49 files", "Solc 0.8.25 finished in 20.76s"),
  `Format` ran `forge fmt`, and `Assert committed artifacts match freshly built`
  ran `git diff --exit-code` clean. The three `-` steps (`Regenerate meta
  artifacts`, `Copy forge artifacts into committed location`, `Regenerate
  derived artifacts`) skip on `hashFiles()` of `script/build-meta.sh`,
  `script/CopyArtifacts.sol` and `script/build.sh`, none of which this repo has.
  Fails on base trivially: on `main` the workflow does not exist, so there is no
  run at all.
- Mutations applied: `src/generated/candidate/AddressRegistry.sol` line 8 →
  `BYTECODE_HASH` last byte `0x97` → `0xde` → killed by the new workflow on
  branch `qa-git-clean-red-check`, run
  https://github.com/rainlanguage/rain.deploy/actions/runs/33044029088, which
  failed at `Assert committed artifacts match freshly built` printing the exact
  one-line diff restoring `0x97`. That proves `Build.sol` really rewrote the
  file and that `git diff` really read the result — a workflow that skipped
  regeneration would have gone green on the corrupted pin.
- Oracle: the reusable workflow's own definition in rainix
  (`rainix-copy-artifacts.yaml`), read to enumerate which steps are
  unconditional and which are `hashFiles()`-gated, and the two conforming
  siblings' caller files for the shape. Expected step list derived from the
  reusable before the run, not read back off it.
- Category check: issue asks for the missing `rainix-copy-artifacts` currency
  check under the ruled `git-clean` names; covered. The issue also names
  rain.extrospection.deploy as missing it — out of scope here, tracked at
  rainlanguage/rain.extrospection.deploy#7 per the ruling comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
