### PR TITLE
Create every fork before selecting any

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ relocated.
 - **`slither.config.json` filters those abstracts by exact filename, never by
   the `src/abstract/` prefix.** Keep it that way when adding an abstract: a
   prefix filter would silently exempt a deployable file added there later.
-- **A `vm.createSelectFork` failure is not a missing deployment.** It is an
-  unreachable or rate-limited endpoint. Only `NotDeployedOnNetwork`, from a
-  network that forked, says anything about the deployment.
+- **A `vm.createFork` or `vm.createSelectFork` failure is not a missing
+  deployment.** It is an unreachable or rate-limited endpoint. Only
+  `NotDeployedOnNetwork`, from a network that forked, says anything about the
+  deployment. The deploy and the chain matrix create every fork before selecting
+  any, so such a failure takes the whole run before any network is checked
+  rather than stopping partway down the list.

--- a/src/abstract/RainDeployVerifyChain.sol
+++ b/src/abstract/RainDeployVerifyChain.sol
@@ -120,11 +120,9 @@ abstract contract RainDeployVerifyChain is RainDeployVerifyBase {
         }
 
         string[] memory networks = LibRainDeploy.supportedNetworks();
+        uint256[] memory forkIds = LibRainDeploy.createForks(vm, networks);
         for (uint256 i = 0; i < networks.length; i++) {
-            // createSelectFork returns a fork id that is not needed here; bind
-            // and reference it so the unused-return lint stays satisfied.
-            uint256 forkId = vm.createSelectFork(networks[i]);
-            (forkId);
+            vm.selectFork(forkIds[i]);
             for (uint256 j = 0; j < derived.length; j++) {
                 checkDeployedOnNetwork(networks[i], derived[j]);
             }

--- a/src/lib/LibRainDeploy.sol
+++ b/src/lib/LibRainDeploy.sol
@@ -254,6 +254,33 @@ library LibRainDeploy {
         return deployedAddress;
     }
 
+    /// Creates a fork for every network, returning their ids in list order.
+    /// Nothing is selected here: the caller selects each in turn.
+    ///
+    /// Creating them all BEFORE the first one is selected is the whole point.
+    /// Foundry captures the account set of the pre-fork EVM when the first fork
+    /// is selected, and seeds every fork CREATED after that capture with it, so
+    /// any address the calling script touched beforehand is carried onto the
+    /// second and later networks as the empty account the default 31337 EVM has
+    /// for it. A `dep.code.length` read added to a deploy script for logging is
+    /// enough. Forks created before the capture read their chain, which is why
+    /// the first network was always right and every one after it was wrong.
+    ///
+    /// Closed here rather than by a rule about what a deploy script may read,
+    /// because the trap is invisible from where a consumer sits: the read is
+    /// ordinary, the failure names a real address on a network that really has
+    /// it, and nothing connects the two.
+    /// @param vm The Vm instance to fork with.
+    /// @param networks The network names to fork, as `[rpc_endpoints]` aliases.
+    /// @return The fork id of each network, positionally paired.
+    function createForks(Vm vm, string[] memory networks) internal returns (uint256[] memory) {
+        uint256[] memory forkIds = new uint256[](networks.length);
+        for (uint256 i = 0; i < networks.length; i++) {
+            forkIds[i] = vm.createFork(networks[i]);
+        }
+        return forkIds;
+    }
+
     /// Returns the list of networks currently supported by Rain deployments.
     /// @return The list of supported network names.
     function supportedNetworks() internal pure returns (string[] memory) {
@@ -390,11 +417,9 @@ library LibRainDeploy {
         if (readCalls.length == 0) {
             revert NoResolvedAddressReads(target);
         }
+        uint256[] memory forkIds = createForks(vm, networks);
         for (uint256 i = 0; i < networks.length; i++) {
-            // createSelectFork returns a fork id that is not needed here; bind
-            // and reference it so the unused-return lint stays satisfied.
-            uint256 forkId = vm.createSelectFork(networks[i]);
-            (forkId);
+            vm.selectFork(forkIds[i]);
             console2.log("Checking resolved addresses on network:", networks[i]);
             checkResolvedAddresses(networks[i], target, readCalls, expectedAddresses);
         }
@@ -415,8 +440,13 @@ library LibRainDeploy {
     /// already-deployed dependency as missing and abort an otherwise-valid
     /// deploy. Each network is handled independently: the Zoltu deploy is
     /// idempotent (an existing contract is skipped), so a failure on one network
-    /// leaves the others intact and the script can simply be re-run, which is why
-    /// no separate all-network pre-flight is needed.
+    /// leaves the others intact and the script can simply be re-run.
+    ///
+    /// The forks themselves are all created up front, before any is selected —
+    /// `createForks` says why it has to be that way round. Endpoint reachability
+    /// is therefore the one thing that IS all-network: an alias that cannot be
+    /// forked stops the run before anything is broadcast, rather than partway
+    /// through it.
     /// @param vm The Vm instance to use for forking and broadcasting.
     /// @param networks The list of network names to deploy to.
     /// @param deployer The deployer address.
@@ -450,11 +480,9 @@ library LibRainDeploy {
         if (derivedAddress != expectedAddress) {
             revert UnexpectedDeployedAddress(expectedAddress, derivedAddress);
         }
+        uint256[] memory forkIds = createForks(vm, networks);
         for (uint256 i = 0; i < networks.length; i++) {
-            // createSelectFork returns a fork id that is not needed here; bind
-            // and reference it so the unused-return lint stays satisfied.
-            uint256 forkId = vm.createSelectFork(networks[i]);
-            (forkId);
+            vm.selectFork(forkIds[i]);
             console2.log("Deploying to network:", networks[i]);
             console2.log("Block number:", block.number);
 

--- a/test/src/abstract/RainDeployVerifyChain.t.sol
+++ b/test/src/abstract/RainDeployVerifyChain.t.sol
@@ -112,6 +112,39 @@ contract RainDeployVerifyChainTest is ExampleDeploySuites, RainDeployVerifyChain
         this.testSuitesLiveOnEverySupportedNetwork();
     }
 
+    /// The matrix MUST create every fork BEFORE it checks anything on any of
+    /// them, for the reason `LibRainDeploy.createForks` gives: a fork created
+    /// after the first select is seeded with whatever was read before it, so a
+    /// deployed address the caller touched first would read as absent on every
+    /// network but the one the matrix reaches first.
+    ///
+    /// A run that fails on that FIRST network is what makes the order visible.
+    /// The matrix never reached the last supported network, so a fork of it
+    /// exists only if it was created up front.
+    function testChainMatrixCreatesEveryForkFirst() external {
+        vm.etch(ADDRESS_REGISTRY_DEPLOYED_ADDRESS, hex"");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NotDeployedOnNetwork.selector,
+                LibRainDeploy.ARBITRUM_ONE,
+                "address-registry-0-0-1",
+                ADDRESS_REGISTRY_DEPLOYED_ADDRESS
+            )
+        );
+        this.testSuitesLiveOnEverySupportedNetwork();
+
+        // This test forks nothing of its own, so the matrix's forks are ids 0
+        // upwards in `supportedNetworks()` order. Selecting the last of them at
+        // all is the assertion; the chain ids say it is a different network
+        // from the one the failure named, rather than another fork of it.
+        uint256 lastNetwork = LibRainDeploy.supportedNetworks().length - 1;
+        vm.selectFork(0);
+        uint256 firstChainId = block.chainid;
+        vm.selectFork(lastNetwork);
+        assertNotEq(block.chainid, firstChainId);
+    }
+
     /// EVERY suite MUST be checked, not just the first one the matrix
     /// reaches. The version missing here is the LAST one, so a matrix that
     /// stopped after the first version would pass.

--- a/test/src/lib/LibRainDeploy.t.sol
+++ b/test/src/lib/LibRainDeploy.t.sol
@@ -235,6 +235,67 @@ contract LibRainDeployTest is Test {
         assertEq(LibRainDeploy.ZOLTU_FACTORY.codehash, LibRainDeploy.ZOLTU_FACTORY_CODEHASH);
     }
 
+    /// `createForks` MUST create every fork and select NONE of them, because
+    /// creating them all before the first select is the whole of what it is for.
+    ///
+    /// Foundry captures the account set of the pre-fork EVM when the first fork
+    /// is SELECTED, and seeds every fork created after that capture with it. A
+    /// `createForks` that selected as it went would put every fork but the first
+    /// on the wrong side of that capture, which is the defect it exists to
+    /// remove.
+    function testCreateForksSelectsNothing() external {
+        string[] memory networks = new string[](2);
+        networks[0] = LibRainDeploy.BASE;
+        networks[1] = LibRainDeploy.ARBITRUM_ONE;
+
+        uint256[] memory forkIds = LibRainDeploy.createForks(vm, networks);
+        assertEq(forkIds.length, 2);
+
+        // `activeFork()` reverts when nothing is selected, so the call failing
+        // is the assertion. Made low level for that reason: a plain `vm` call
+        // would take the test down with it.
+        (bool active,) = address(vm).call(abi.encodeWithSignature("activeFork()"));
+        assertFalse(active, "createForks selected a fork");
+
+        // Every id it handed back is a real fork of the network in that
+        // position, so nothing was skipped or forked twice.
+        vm.selectFork(forkIds[0]);
+        assertEq(block.chainid, BASE_CHAIN_ID);
+        vm.selectFork(forkIds[1]);
+        assertEq(block.chainid, ARBITRUM_ONE_CHAIN_ID);
+    }
+
+    /// A read the caller made BEFORE any fork existed MUST NOT decide what a
+    /// `createForks` fork holds, on any network.
+    ///
+    /// The read here is the one a deploy script makes for logging, and on the
+    /// default 31337 EVM it answers zero for an address that is on every chain
+    /// this repo deploys to. Forks created after the first select are seeded
+    /// with that answer, so the whole difference between a network that reads
+    /// its chain and one that reports the Zoltu factory missing is the order
+    /// the forks were created in.
+    function testCreateForksIgnoresAPreForkRead() external {
+        // The poisoning read, before anything is forked.
+        assertEq(LibRainDeploy.ZOLTU_FACTORY.code.length, 0);
+
+        string[] memory networks = new string[](2);
+        networks[0] = LibRainDeploy.BASE;
+        networks[1] = LibRainDeploy.ARBITRUM_ONE;
+
+        uint256[] memory forkIds = LibRainDeploy.createForks(vm, networks);
+
+        // The SECOND network is the one that reads the pre-fork answer when the
+        // forks are created as the loop reaches them. Both are asserted so a
+        // first network that broke would be seen as well.
+        vm.selectFork(forkIds[0]);
+        assertEq(block.chainid, BASE_CHAIN_ID);
+        assertEq(LibRainDeploy.ZOLTU_FACTORY.codehash, LibRainDeploy.ZOLTU_FACTORY_CODEHASH);
+
+        vm.selectFork(forkIds[1]);
+        assertEq(block.chainid, ARBITRUM_ONE_CHAIN_ID);
+        assertEq(LibRainDeploy.ZOLTU_FACTORY.codehash, LibRainDeploy.ZOLTU_FACTORY_CODEHASH);
+    }
+
     /// External wrapper for `deployAndBroadcast` so that
     /// `vm.expectRevert` works at the correct call depth.
     /// @param networks The list of network names to deploy to.
@@ -318,6 +379,50 @@ contract LibRainDeployTest is Test {
         assertEq(block.chainid, BASE_CHAIN_ID);
         assertEq(result.codehash, mockDeployableCodeHash());
 
+        vm.selectFork(1);
+        assertEq(block.chainid, ARBITRUM_ONE_CHAIN_ID);
+        assertEq(result.codehash, mockDeployableCodeHash());
+    }
+
+    /// A read of a declared dependency BEFORE any fork exists MUST NOT change
+    /// what `deployToNetworks` sees on any network.
+    ///
+    /// This is rainlanguage/rain.deploy#157 end to end. A deploy script that
+    /// logs `dependencies[i].code.length` executes that read on the default
+    /// 31337 EVM, where the account is empty, and every fork created after the
+    /// first select is seeded with it — so the first network read its chain and
+    /// every one after it reverted `MissingDependency` against a dependency
+    /// that demonstrably has code there. It cost several failed production
+    /// deploy runs to diagnose, because the check itself is sound and the
+    /// address it names is real.
+    ///
+    /// The dependency is the Zoltu factory because it is the one address this
+    /// repo knows is live on every supported network, so the second network
+    /// disagreeing with the first can only be the defect and never the chain.
+    function testDeployToNetworksIgnoresAPreForkDependencyRead() external {
+        // The read a deploy script makes for logging, before anything forks.
+        assertEq(LibRainDeploy.ZOLTU_FACTORY.code.length, 0);
+
+        string[] memory networks = new string[](2);
+        networks[0] = LibRainDeploy.BASE;
+        networks[1] = LibRainDeploy.ARBITRUM_ONE;
+
+        address[] memory dependencies = new address[](1);
+        dependencies[0] = LibRainDeploy.ZOLTU_FACTORY;
+
+        address result = this.externalDeployToNetworks(
+            networks,
+            address(this),
+            type(MockDeployable).creationCode,
+            "test/concrete/MockDeployable.sol:MockDeployable",
+            mockDeployableAddress(),
+            mockDeployableCodeHash(),
+            dependencies
+        );
+        assertEq(result, mockDeployableAddress());
+
+        // The second network is the one the pre-fork read used to take out, and
+        // a deploy landed on it.
         vm.selectFork(1);
         assertEq(block.chainid, ARBITRUM_ONE_CHAIN_ID);
         assertEq(result.codehash, mockDeployableCodeHash());
@@ -1249,6 +1354,46 @@ contract LibRainDeployTest is Test {
             )
         );
         this.externalCheckResolvedAddressesOnNetworks(networks, address(target), ownerReadCalls(), expected(account));
+    }
+
+    /// `checkResolvedAddressesOnNetworks` MUST create every fork BEFORE it
+    /// checks anything on any of them, for the reason `createForks` gives: a
+    /// fork created after the first select is seeded with whatever the caller
+    /// read before the call, so a target it logged would read as having no code
+    /// on every network but the first.
+    ///
+    /// A run that fails on the FIRST network is what makes the order visible
+    /// from outside. The loop never reached the second network, so a fork of it
+    /// exists only if it was created up front.
+    function testCheckResolvedAddressesOnNetworksCreatesEveryForkFirst() external {
+        bytes32 name = keccak256("testCheckResolvedAddressesOnNetworksCreatesEveryForkFirst");
+        address account = address(0xf00);
+        address wrong = address(0xba4);
+        (, MockResolvedOwner consumer) = deployRegistryAndConsumer(name, account);
+        vm.makePersistent(address(consumer));
+
+        string[] memory networks = new string[](2);
+        networks[0] = LibRainDeploy.ARBITRUM_ONE;
+        networks[1] = LibRainDeploy.BASE;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibRainDeploy.UnexpectedResolvedAddress.selector,
+                LibRainDeploy.ARBITRUM_ONE,
+                address(consumer),
+                uint256(0),
+                wrong,
+                account
+            )
+        );
+        this.externalCheckResolvedAddressesOnNetworks(networks, address(consumer), ownerReadCalls(), expected(wrong));
+
+        // This test forks nothing of its own, so ids 0 and 1 are the call's, in
+        // the order it was given. Selecting id 1 at all is the assertion; the
+        // chain id says it is the second network rather than another fork of
+        // the first.
+        vm.selectFork(1);
+        assertEq(block.chainid, BASE_CHAIN_ID);
     }
 
     /// `deployToNetworks` MUST deploy when every dependency has code on the


### PR DESCRIPTION
Closes #157

## The defect

`LibRainDeploy` and `RainDeployVerifyChain` walked their network lists with
`vm.createSelectFork` inside the loop. Foundry captures the account set of the
pre-fork EVM when the **first fork is selected**, and seeds every fork **created
after** that capture with it. With `createSelectFork` in the loop, networks
2..n are all created on the wrong side of that capture, so they inherit whatever
the default 31337 EVM held for any address the calling script had already
touched — an empty account.

A `dep.code.length` read in a deploy script, typically added for logging, is
enough. The first network read its chain; every network after it reverted
`MissingDependency` against a dependency that demonstrably has code there.
Forks created *before* the capture read their own chain, which is exactly why
the first network was always right.

## The fix

Create every fork up front, then select each in turn. `LibRainDeploy.createForks`
creates and selects nothing; three call sites use it:

- `LibRainDeploy.deployToNetworks`
- `LibRainDeploy.checkResolvedAddressesOnNetworks`
- `RainDeployVerifyChain.checkDeployedOnSupportedNetworks`

This puts every network on the same side of the capture as the first one already
was.

Closed in the library rather than by a rule about what a deploy script may read,
because the trap is invisible from where a consumer sits: the read is ordinary,
the failure names a real address on a network that really has it, and nothing
connects the two.

### Alternatives rejected

- **`vm.makePersistent`** on the dependencies pins the *empty* account across
  every fork. It makes the bug unconditional rather than fixing it.
- **`rollFork`** does not re-seed the account set at all.
- **`vm.rpc`** sidesteps forking but changes the dependency check's semantics.
  The check is meant to read the same fork the deploy then broadcasts on, so
  that a transient RPC inconsistency between two separate reads cannot report a
  live dependency as missing and abort an otherwise-valid deploy.

## Two limits, stated plainly

**1. It cannot rescue a caller that has already selected a fork before calling.**
The capture happens at the first select. A caller that selects a fork first has
already triggered it, so `createForks` runs afterwards and its forks inherit the
poisoned set. There is no in-library fix for that ordering.

This does not affect the reported path. `RainDeployBroadcast.run()` forks nothing
before calling `deployAndBroadcast`: `checkCandidatesAnchoredToSource()` and
`suiteByName()` are both `internal pure`, and `vm.envUint` does not fork.

**2. Endpoint reachability is now all-network.** Every alias must be forkable
before any network is touched, so one unreachable endpoint fails the run at fork
creation rather than after the earlier networks have already been checked and
their deploys simulated. It is all-or-nothing on reachability instead of
stopping partway down the list.

To be precise about what that does **not** change: it does not change what
reaches a chain. Verified locally against two anvils, with a reachable first
endpoint and an unreachable second one:

| shape | fails at | first chain's block after the run |
| --- | --- | --- |
| `createSelectFork` in the loop (before) | the second iteration, after the first network's deploy was simulated and recorded | `0x0` |
| `createFork` up front (after) | fork creation, before any network's work | `0x0` |

`forge script` sends only after the whole script has executed, so an aborted
script broadcast nothing under either shape. What changes is how far the run
gets, and therefore what an operator sees before the endpoint error — not what
lands on chain.

A consequence worth naming: paths that used to short-circuit now contact every
endpoint. The chain matrix that reverts on the first network previously never
forked the remaining six; it now forks all seven before checking any. That is
inherent to the fix, and it raises this suite's exposure to a flaky endpoint
(see QA).

## QA

- Discriminating tests: `testDeployToNetworksIgnoresAPreForkDependencyRead`, `testCheckResolvedAddressesOnNetworksCreatesEveryForkFirst`, `testChainMatrixCreatesEveryForkFirst`, `testCreateForksSelectsNothing`, `testCreateForksIgnoresAPreForkRead` - each fails on base, verified by reverting its own call site to `createSelectFork` and running the whole suite (table below), not by reasoning about it.
- Mutations applied: `LibRainDeploy.deployToNetworks` -> `createForks`+`selectFork` reverted to `createSelectFork` in the loop -> killed by `testDeployToNetworksIgnoresAPreForkDependencyRead`; `LibRainDeploy.checkResolvedAddressesOnNetworks` -> same revert -> killed by `testCheckResolvedAddressesOnNetworksCreatesEveryForkFirst`; `RainDeployVerifyChain.checkDeployedOnSupportedNetworks` -> same revert -> killed by `testChainMatrixCreatesEveryForkFirst`. Each site reverted individually with the other two left fixed; restores verified byte-exact against pristine copies.
- Oracle: live chain state, read independently of this library. The Zoltu factory `0x7A0D94F55792C434d74a40883C6ed8545E406D12` does have code on arbitrum, so the mutant's `MissingDependency("arbitrum", 0x7A0D...)` is a demonstrable false negative rather than an expected result. Fork block numbers come from the endpoints themselves.
- Category check: #157 asks for one thing - the library must stop networks after the first inheriting a pre-fork read, rather than leaving each consumer to avoid the read. Covered at all three call sites. The issue's second limb, a repo-wide sweep for the same pattern, found no other defect: `RainDeployVerifyBase.deriveDeployment` does read `factoryAddress.codehash` pre-fork, but its own `snapshotState`/`revertToState` clears the capture, verified rather than assumed; every other `.code`/`.codehash` read is behind `vm.makePersistent` or already inside a fork.

**Full suite.** `forge test` — 350 passed, 0 failed, 0 skipped.

**Mutation testing.** Each of the three changed call sites was individually
reverted to `createSelectFork` in the loop, with the other two left fixed, and
the whole suite run. Every site has a test that dies without it:

| reverted site | test that dies | failure |
| --- | --- | --- |
| `RainDeployVerifyChain.sol` `checkDeployedOnSupportedNetworks` | `testChainMatrixCreatesEveryForkFirst` | `vm.selectFork: No matching fork found for 6` |
| `LibRainDeploy.sol` `checkResolvedAddressesOnNetworks` | `testCheckResolvedAddressesOnNetworksCreatesEveryForkFirst` | `vm.selectFork: No matching fork found for 1` |
| `LibRainDeploy.sol` `deployToNetworks` | `testDeployToNetworksIgnoresAPreForkDependencyRead` | `MissingDependency("arbitrum", 0x7A0D94F55792C434d74a40883C6ed8545E406D12)` |

The last is the exact failure #157 reports.

**Pre-existing HyperEVM flakiness, not from this diff.** Across repeated full-suite
runs, `rpc.hyperliquid.xyz` intermittently answers
`error code -32603: invalid block height: <head>`, failing whichever test forks
it first that run. It has been seen on `testZoltuFactoryCodehash`,
`testCreditOnAHyperEvmFork`, `testCreditOnHyperEvmForksTheAliasBeforeItsGuards`,
`testTheLiveSystemContractIsWhatIsPinned` and
`testChainMatrixReachesTheLastSupportedNetwork` — untouched tests, forking
HyperEVM through `createSelectFork` as they always did. It is the endpoint
serving a node behind the head, and it is precisely the failure class CLAUDE.md
calls out. Re-running clears it. Noting it because CI may need a re-run, and
because the change does raise the number of HyperEVM forks per run.

## Docs

`CLAUDE.md`'s "a fork failure is not a missing deployment" note named
`vm.createSelectFork` only. The paths it is about now fail under `vm.createFork`,
so the note names both and records that the failure is now up front.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network deployment and verification now create all required network forks before running checks or broadcasts.
  * A failure to create any fork is reported before network validation or deployment begins.
  * Pre-fork blockchain reads no longer affect code or dependency checks on subsequently created forks.

* **Tests**
  * Added coverage confirming fork creation order and isolation across deployment, verification, and address-resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->